### PR TITLE
package doesn't export private recom functions

### DIFF
--- a/src/GerryChain.jl
+++ b/src/GerryChain.jl
@@ -22,11 +22,9 @@ PopulationConstraint,
 satisfy_constraint,
 
 # recom
-sample_subgraph, build_mst, add_edge_to_mst!, remove_edge_from_mst!,
-traverse_mst, get_balanced_proposal, get_valid_proposal, update_partition!,
-recom_chain,
+update_partition!, recom_chain,
 
-# measures
+# scores
 get_scores, get_scores_at_step
 
 include("./graph.jl")

--- a/test/graph.jl
+++ b/test/graph.jl
@@ -1,3 +1,7 @@
+using LightGraphs
+using Random
+using DataStructures
+
 """
     the test graph being loaded is labeled as
 
@@ -77,8 +81,8 @@
     @test sort(graph.neighbors[14]) == [10, 13, 15]
 
     # test the simple graph
-    @test nv(graph.simple_graph) == graph.num_nodes
-    @test ne(graph.simple_graph) == graph.num_edges
+    @test LightGraphs.nv(graph.simple_graph) == graph.num_nodes
+    @test LightGraphs.ne(graph.simple_graph) == graph.num_edges
 
     # test induced_subgraph
     @test begin

--- a/test/recom.jl
+++ b/test/recom.jl
@@ -1,3 +1,4 @@
+using DataStructures
 
 @testset "Recom tests" begin
     graph = BaseGraph(filepath, "population", "assignment")
@@ -7,13 +8,13 @@
         edges = [graph.adj_matrix[1,5], graph.adj_matrix[5,6], graph.adj_matrix[2,6],
                  graph.adj_matrix[2,3], graph.adj_matrix[3,7], graph.adj_matrix[3,4],
                  graph.adj_matrix[4,8]]
-        mst = build_mst(graph, BitSet(nodes), BitSet(edges))
+        mst = GerryChain.build_mst(graph, BitSet(nodes), BitSet(edges))
         stack = Stack{Int}()
         component_container = BitSet([])
         cut_edge = graph.adj_matrix[2,3]
-        component = traverse_mst(mst, 2, 3, stack, component_container)
+        component = GerryChain.traverse_mst(mst, 2, 3, stack, component_container)
         @test component == BitSet([1, 2, 5, 6])
-        component = traverse_mst(mst, 1, 5, stack, component_container)
+        component = GerryChain.traverse_mst(mst, 1, 5, stack, component_container)
         @test component == BitSet([1])
     end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,8 +1,5 @@
 using GerryChain
 using Test
-using LightGraphs
-using Random
-using DataStructures
 
 const testdir = dirname(@__FILE__)
 filepath = "./test_grid_4x4.json"


### PR DESCRIPTION
* Figured out how to test unexported Package functions (use GerryChain.funcName when calling those functions)
* Moved dependencies (like DataStructures.jl) from runtests.jl to only the test files that uses them. Cleaner for namespace reasons, and forces more intent from the programmer writing tests.
