### PR TITLE
Custom acceptance functions

### DIFF
--- a/src/GerryChain.jl
+++ b/src/GerryChain.jl
@@ -32,6 +32,9 @@ flip_chain,
 # scores
 get_scores, get_scores_at_step,
 
+# acceptance functions
+always_accept,
+
 # election
 AbstractElection, Election, update_elections!, seats_won, total_vote_counts,
 vote_counts_by_district, vote_shares_by_district,
@@ -46,6 +49,7 @@ include("./constraints.jl")
 include("./scores.jl")
 include("./recom.jl")
 include("./flip.jl")
+include("./accept.jl")
 include("./election.jl")
 include("./partisan_metrics.jl")
 

--- a/src/GerryChain.jl
+++ b/src/GerryChain.jl
@@ -33,7 +33,7 @@ flip_chain,
 get_scores, get_scores_at_step,
 
 # acceptance functions
-always_accept,
+always_accept, pass_acceptance_fn,
 
 # election
 AbstractElection, Election, update_elections!, seats_won, total_vote_counts,

--- a/src/GerryChain.jl
+++ b/src/GerryChain.jl
@@ -33,7 +33,7 @@ flip_chain,
 get_scores, get_scores_at_step,
 
 # acceptance functions
-always_accept, pass_acceptance_fn,
+always_accept, satisfies_acceptance_fn,
 
 # election
 AbstractElection, Election, update_elections!, seats_won, total_vote_counts,

--- a/src/accept.jl
+++ b/src/accept.jl
@@ -5,10 +5,11 @@ function always_accept(partition::Partition)
 end
 
 
-function pass_acceptance_fn(partition::Partition, acceptance_fn::Function)
+function satisfies_acceptance_fn(partition::Partition,
+                                 acceptance_fn::Function)::Bool
     """ Determines whether a partition should be accepted, according to the
         user-specified acceptance function. Acceptance function must
-        return a valid probability in [0, 1], and pass_acceptance_fn will
+        return a valid probability in [0, 1], and satisfies_acceptance_fn will
         use this probability to determine whether the partition should be
         accepted.
 

--- a/src/accept.jl
+++ b/src/accept.jl
@@ -1,0 +1,3 @@
+function always_accept(partition::Partition, graph::BaseGraph)
+    return 1
+end

--- a/src/accept.jl
+++ b/src/accept.jl
@@ -1,3 +1,41 @@
-function always_accept(partition::Partition, graph::BaseGraph)
+function always_accept(partition::Partition)
+    """ Accepts new partition with probability 1.
+    """
     return 1
+end
+
+
+function pass_acceptance_fn(partition::Partition, acceptance_fn::Function)
+    """ Determines whether a partition should be accepted, according to the
+        user-specified acceptance function. Acceptance function must
+        return a valid probability in [0, 1], and pass_acceptance_fn will
+        use this probability to determine whether the partition should be
+        accepted.
+
+        Arguments:
+            partition:      Partition. Should have a valid "parent" field
+                            so the acceptance function can compare the new
+                            partition to the previous partition, if necessary.
+            acceptance_fn:  A user-specified function that should take
+                            partition as an argument and return a probability
+                            in the range [0, 1].
+    """
+    # check that partition has a valid parent
+    @assert partition.parent != nothing
+    prob = 0.0
+    try
+        prob = acceptance_fn(partition)
+        if !(typeof(prob) <: Number) || prob < 0 || prob > 1
+            error_msg = "Acceptance function must return value in [0, 1] range."
+            throw(ArgumentError(error_msg))
+        end
+    catch e
+        if isa(e, MethodError)
+            error_msg = "Acceptance function must accept Partition as input."
+            throw(MethodError(error_msg))
+        else
+            throw(e)
+        end
+    end
+    return rand() <= prob
 end

--- a/src/flip.jl
+++ b/src/flip.jl
@@ -129,7 +129,7 @@ function flip_chain(graph::BaseGraph,
                                       cont_constraint)
         custom_acceptance = acceptance_fn !== always_accept
         update_partition!(partition, graph, proposal, custom_acceptance)
-        if custom_acceptance && !pass_acceptance_fn(partition, acceptance_fn)
+        if custom_acceptance && !satisfies_acceptance_fn(partition, acceptance_fn)
             # go back to the previous partition
             partition = partition.parent
         end

--- a/src/flip.jl
+++ b/src/flip.jl
@@ -75,9 +75,16 @@ end
 
 function update_partition!(partition::Partition,
                            graph::BaseGraph,
-                           proposal::FlipProposal)
+                           proposal::FlipProposal,
+                           copy_parent::Bool=false)
     """ Updates the Partition with the FlipProposal
     """
+    if copy_parent
+        partition.parent = nothing
+        old_partition = deepcopy(partition)
+        partition.parent = old_partition
+    end
+
     # update district population counts
     partition.dist_populations[proposal.D₁] = proposal.D₁_pop
     partition.dist_populations[proposal.D₂] = proposal.D₂_pop
@@ -99,7 +106,7 @@ function flip_chain(graph::BaseGraph,
                     num_steps::Int,
                     score_keys::Array{String, 1},
                     scores_save_dir::AbstractString="./scores.json",
-                    num_tries::Int=3)
+                    acceptance_fn::Function=always_accept)
     """ Runs a Markov Chain for `num_steps` steps using Flip proposals.
 
         Arguments:
@@ -110,6 +117,9 @@ function flip_chain(graph::BaseGraph,
             score_keys:         list of scores to evaluate plans with
             score_save_dir:     directory of where to store the scores
             num_steps:          Number of steps to run the chain for
+            acceptance_fn:      A function generating a probability in [0, 1]
+                                representing the likelihood of accepting the
+                                proposal
     """
     steps_taken = 0
     all_scores = Array{Dict{String, Any}, 1}()

--- a/src/partition.jl
+++ b/src/partition.jl
@@ -5,6 +5,7 @@ mutable struct Partition
     cut_edges::Array{Int, 1}                    # of length(num_edges)
     dist_adj::SparseMatrixCSC{Int, Int}
     dist_nodes::Array{BitSet}
+    parent::Union{Partition, Nothing}           # optional parent partition
 end
 
 function Partition(filepath::AbstractString,
@@ -40,8 +41,9 @@ function Partition(filepath::AbstractString,
     # get district_nodes
     dist_nodes = get_district_nodes(assignments, graph.num_nodes, graph.num_dists)
 
+    # return Partition with no parent by default
     return Partition(num_cut_edges, assignments, dist_populations, cut_edges,
-                     dist_adj, dist_nodes)
+                     dist_adj, dist_nodes, nothing)
 end
 
 function get_district_nodes(assignments::Array{Int, 1},

--- a/src/recom.jl
+++ b/src/recom.jl
@@ -182,17 +182,14 @@ function update_partition!(partition::Partition,
 end
 
 
-function
-
-
 function recom_chain(graph::BaseGraph,
                      partition::Partition,
                      pop_constraint::PopulationConstraint,
                      num_steps::Int,
-                     score_keys::Array{String, 1},
+                     score_keys::Array{String, 1};
                      scores_save_dir::AbstractString="./scores.json",
                      num_tries::Int=3,
-                     acceptance_fn::Function=always_accept)
+                     acceptance_fn::F=always_accept) where {F<:Function}
     """ Runs a Markov Chain for `num_steps` steps using ReCom.
 
         Arguments:
@@ -204,15 +201,19 @@ function recom_chain(graph::BaseGraph,
                             before giving up
             acceptance_fn:  A function generating a probability in [0, 1]
                             representing the likelihood of accepting the
-                            proposal
+                            proposal. Should accept a Partition as input.
     """
     steps_taken = 0
     all_scores = Array{Dict{String, Any}, 1}()
 
     while steps_taken < num_steps
-        proposal = get_valid_proposal(graph, partition, pop_constraint, num_tries)            
-        update_partition!(partition, graph, proposal)
-
+        proposal = get_valid_proposal(graph, partition, pop_constraint, num_tries)
+        custom_acceptance = acceptance_fn !== always_accept
+        update_partition!(partition, graph, proposal, custom_acceptance)
+        if custom_acceptance && !pass_acceptance_fn(partition, acceptance_fn)
+            # go back to the previous partition
+            partition = partition.parent
+        end
         scores = get_scores(graph, partition, score_keys, steps_taken, proposal)
         push!(all_scores, scores)
         steps_taken += 1

--- a/src/recom.jl
+++ b/src/recom.jl
@@ -210,7 +210,7 @@ function recom_chain(graph::BaseGraph,
         proposal = get_valid_proposal(graph, partition, pop_constraint, num_tries)
         custom_acceptance = acceptance_fn !== always_accept
         update_partition!(partition, graph, proposal, custom_acceptance)
-        if custom_acceptance && !pass_acceptance_fn(partition, acceptance_fn)
+        if custom_acceptance && !satisfies_acceptance_fn(partition, acceptance_fn)
             # go back to the previous partition
             partition = partition.parent
         end

--- a/test/accept.jl
+++ b/test/accept.jl
@@ -1,0 +1,22 @@
+@testset "pass_acceptance_fn" begin
+    graph = BaseGraph(square_grid_filepath, "population", "assignment")
+    partition = Partition(square_grid_filepath, graph, "population", "assignment")
+
+    inval_acc_fn_1(p) = "hi"
+    inval_acc_fn_2(p) = -3
+    inval_acc_fn_3(x,y) = x*y
+    always_pass(p) = 1.0
+    always_fail(p) = 0.0
+
+    # partition doesn't have a "parent" defined yet, so the call to
+    # pass_acceptance_fn should fail here. As a reminder, all partitions
+    # passed to an acceptance function should have the parent field assigned.
+    @test_throws AssertionError pass_acceptance_fn(partition, always_accept)
+
+    partition.parent = deepcopy(partition)
+    @test_throws ArgumentError pass_acceptance_fn(partition, inval_acc_fn_1)
+    @test_throws ArgumentError pass_acceptance_fn(partition, inval_acc_fn_2)
+    @test_throws MethodError pass_acceptance_fn(partition, inval_acc_fn_3)
+    @test pass_acceptance_fn(partition, always_pass) == true
+    @test pass_acceptance_fn(partition, always_fail) == false
+end

--- a/test/accept.jl
+++ b/test/accept.jl
@@ -1,4 +1,4 @@
-@testset "pass_acceptance_fn" begin
+@testset "satisfies_acceptance_fn" begin
     graph = BaseGraph(square_grid_filepath, "population", "assignment")
     partition = Partition(square_grid_filepath, graph, "population", "assignment")
 
@@ -9,14 +9,14 @@
     always_fail(p) = 0.0
 
     # partition doesn't have a "parent" defined yet, so the call to
-    # pass_acceptance_fn should fail here. As a reminder, all partitions
+    # satisfies_acceptance_fn should fail here. As a reminder, all partitions
     # passed to an acceptance function should have the parent field assigned.
-    @test_throws AssertionError pass_acceptance_fn(partition, always_accept)
+    @test_throws AssertionError satisfies_acceptance_fn(partition, always_accept)
 
     partition.parent = deepcopy(partition)
-    @test_throws ArgumentError pass_acceptance_fn(partition, inval_acc_fn_1)
-    @test_throws ArgumentError pass_acceptance_fn(partition, inval_acc_fn_2)
-    @test_throws MethodError pass_acceptance_fn(partition, inval_acc_fn_3)
-    @test pass_acceptance_fn(partition, always_pass) == true
-    @test pass_acceptance_fn(partition, always_fail) == false
+    @test_throws ArgumentError satisfies_acceptance_fn(partition, inval_acc_fn_1)
+    @test_throws ArgumentError satisfies_acceptance_fn(partition, inval_acc_fn_2)
+    @test_throws MethodError satisfies_acceptance_fn(partition, inval_acc_fn_3)
+    @test satisfies_acceptance_fn(partition, always_pass) == true
+    @test satisfies_acceptance_fn(partition, always_fail) == false
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -12,6 +12,7 @@ tests = [
     "flip",
     "recom",
     "scores",
+    "accept",
     "election",
     "partisan_metrics"
 ]


### PR DESCRIPTION
In this PR, I implement functionality that allows the user to pass in a custom acceptance function to `recom_chain` and `flip_chain.` Acceptance functions allow users to compare an updated partition (i.e., the next step in the chain) to the original partition and decide a probability with which to accept or reject the updated partition. (The probability may be 0 or 1). If the new partition is rejected, the step counter is incremented and the new partition is discarded (i.e., a self-loop in the Markov chain).

- `src/accept.jl` contains a standard acceptance function, `always_accept`, as well as `pass_acceptance_fn`, which takes in the user function for generating the acceptance probability, runs a single Bernoulli trial with that probability, and returns `true` or `false`. I implement checks to ensure various conditions about the user-defined acceptance function hold true, such as whether it returns a probability in the range [0,1].
- `src/flip.jl` and `src/recom.jl` were modified to take as an argument an optional `acceptance_fn` parameter
- Test: `tests/accept.jl` tests `pass_acceptance_fn`

**Performance Impact**
_Without acceptance fxns:_
Recom chain, PA VTD, 100 steps:  6.494099 seconds (2.40 M allocations: 185.112 MiB, 2.90% gc time)
Flip chain, PA VTD, 10000 steps: 32.864040 seconds (180.71 M allocations: 3.036 GiB, 1.83% gc time)

_With acceptance fxns:_
Recom chain, PA VTD, 100 steps:  7.317668 seconds (2.41 M allocations: 185.213 MiB, 3.56% gc time)
Recom chain, PA VTD, 100 steps, with toy acceptance fxn (always returns 0.5):  5.672623 seconds (2.53 M allocations: 223.098 MiB, 3.04% gc time)
Flip chain, PA VTD, 10000 steps:  32.828002 seconds (185.48 M allocations: 3.106 GiB, 1.76% gc time)
Flip chain, PA VTD, 10000 steps, with toy acceptance fxn (always returns 0.5):  38.601872 seconds (183.70 M allocations: 5.836 GiB, 3.21% gc time)

**Conclusion**: No significant time/memory impact on on code without acceptance functions, though we do see **substantial memory allocation increases**, likely due to the copying of the partition every time.