### PR TITLE
Add very basic unit tests for recom_chain and flip_chain and remove global RNG 

### DIFF
--- a/src/constraints.jl
+++ b/src/constraints.jl
@@ -59,6 +59,9 @@ function satisfy_constraint(constraint::ContiguityConstraint, graph::BaseGraph,
     # get node's neighbors who were in its old district
     neighbors = [n for n in graph.neighbors[flip.node]
                  if partition.assignments[n] == flip.D₁]
+    if isempty(neighbors) # this is the only node of this district left!
+        return false
+    end
     source_node = pop!(neighbors)
 
     # DFS search to verify contiguity is not broken

--- a/src/partition.jl
+++ b/src/partition.jl
@@ -102,7 +102,9 @@ function get_district_adj_and_cut_edges(graph::BaseGraph,
     return district_adj, cut_edges
 end
 
-function sample_adjacent_districts_randomly(partition::Partition, num_dists::Int)
+function sample_adjacent_districts_randomly(partition::Partition,
+                                            num_dists::Int,
+                                            rng::AbstractRNG)
     """ Randomly sample two adjacent districts and return them.
     """
     while true

--- a/test/flip.jl
+++ b/test/flip.jl
@@ -21,7 +21,7 @@
         pop_constraint = PopulationConstraint(graph, "population", 10.0)
         cont_constraint = cont_constraint = ContiguityConstraint()
         scores = ["electionD", "electionR", "purple", "pink"]
-        num_steps = 2 # test 2 steps for now
+        num_steps = 1000
 
         function run_chain()
             try

--- a/test/flip.jl
+++ b/test/flip.jl
@@ -15,4 +15,22 @@
         # neighboring nodes
         @test flip_prop.D₂ in neighbor_districts
     end
+
+    @testset "flip_chain()" begin
+        # this is a dummy constraint
+        pop_constraint = PopulationConstraint(graph, "population", 10.0)
+        cont_constraint = cont_constraint = ContiguityConstraint()
+        scores = ["electionD", "electionR", "purple", "pink"]
+        num_steps = 2 # test 2 steps for now
+
+        function run_chain()
+            try
+                flip_chain(graph, partition, pop_constraint, cont_constraint, num_steps, scores)
+            catch ex
+                return ex
+            end
+        end
+        # hacky way to run flip chain and test that it doesn't yield an exception
+        @test !isa(run_chain(), Exception)
+    end
 end

--- a/test/recom.jl
+++ b/test/recom.jl
@@ -15,4 +15,23 @@
         component = GerryChain.traverse_mst(mst, 1, 5, stack, component_container)
         @test component == BitSet([1])
     end
+
+    @testset "recom_chain()" begin
+        partition = Partition(square_grid_filepath, graph, "population", "assignment")
+        # this is a dummy constraint
+        pop_constraint = PopulationConstraint(graph, "population", 10.0)
+        scores = ["electionD", "electionR", "purple", "pink"]
+        num_steps = 2 # test 2 steps for now
+
+        function run_chain()
+            try
+                recom_chain(graph, partition, pop_constraint, num_steps, scores)
+            catch ex
+                return ex
+            end
+        end
+        recom_chain(graph, partition, pop_constraint, num_steps, scores)
+        # hacky way to run flip chain and test that it doesn't yield an exception
+        @test !isa(run_chain(), Exception)
+    end
 end


### PR DESCRIPTION
- Add two unit tests that run 2 steps of a recom/flip chain
- Remove global RNG; allow user option to pass in their own RNG - otherwise, default to `Random.default_rng()`