### PR TITLE
Implemented framework for district & partition-level score functions

### DIFF
--- a/src/GerryChain.jl
+++ b/src/GerryChain.jl
@@ -30,7 +30,11 @@ update_partition!, recom_chain,
 flip_chain,
 
 # scores
-get_scores, get_scores_at_step,
+DistrictAggregate,
+DistrictScore,
+PlanScore,
+score_initial_partition, score_partition_from_proposal, get_scores,
+get_scores_at_step,
 
 # acceptance functions
 always_accept, satisfies_acceptance_fn,

--- a/src/GerryChain.jl
+++ b/src/GerryChain.jl
@@ -33,8 +33,8 @@ flip_chain,
 DistrictAggregate,
 DistrictScore,
 PlanScore,
-score_initial_partition, score_partition_from_proposal, get_scores,
-get_scores_at_step,
+score_initial_partition, score_partition_from_proposal, eval_score_on_district,
+get_scores, get_scores_at_step, eval_score_on_partition, 
 
 # acceptance functions
 always_accept, satisfies_acceptance_fn,

--- a/src/GerryChain.jl
+++ b/src/GerryChain.jl
@@ -34,7 +34,7 @@ DistrictAggregate,
 DistrictScore,
 PlanScore,
 score_initial_partition, score_partition_from_proposal, eval_score_on_district,
-get_scores, get_scores_at_step, eval_score_on_partition, 
+get_scores, get_scores_at_step, eval_score_on_partition, save_scores,
 
 # acceptance functions
 always_accept, satisfies_acceptance_fn,

--- a/src/flip.jl
+++ b/src/flip.jl
@@ -105,7 +105,6 @@ function flip_chain(graph::BaseGraph,
                     cont_constraint::ContiguityConstraint,
                     num_steps::Int,
                     scores::Array{S, 1};
-                    scores_save_dir::AbstractString="./scores.json",
                     acceptance_fn::F=always_accept) where {F<:Function,
                                                            S<:AbstractScore}
     """ Runs a Markov Chain for `num_steps` steps using Flip proposals.

--- a/src/recom.jl
+++ b/src/recom.jl
@@ -190,7 +190,6 @@ function recom_chain(graph::BaseGraph,
                      pop_constraint::PopulationConstraint,
                      num_steps::Int,
                      scores::Array{S, 1};
-                     scores_save_dir::AbstractString="./scores.json",
                      num_tries::Int=3,
                      acceptance_fn::F=always_accept,
                      rng::AbstractRNG=Random.default_rng()) where {F<:Function,

--- a/src/recom.jl
+++ b/src/recom.jl
@@ -189,11 +189,12 @@ function recom_chain(graph::BaseGraph,
                      partition::Partition,
                      pop_constraint::PopulationConstraint,
                      num_steps::Int,
-                     scores::Array{AbstractScore, 1};
+                     scores::Array{S, 1};
                      scores_save_dir::AbstractString="./scores.json",
                      num_tries::Int=3,
                      acceptance_fn::F=always_accept,
-                     rng::AbstractRNG=Random.default_rng()) where {F<:Function}
+                     rng::AbstractRNG=Random.default_rng()) where {F<:Function,
+                                                                   S<:AbstractScore}
     """ Runs a Markov Chain for `num_steps` steps using ReCom.
 
         Arguments:
@@ -212,7 +213,7 @@ function recom_chain(graph::BaseGraph,
     """
     steps_taken = 0
     first_scores = score_initial_partition(graph, partition, scores)
-    all_scores = Array{Dict{String, Any}, 1}([first_scores])
+    chain_scores = Array{Dict{String, Any}, 1}([first_scores])
 
     while steps_taken < num_steps
         proposal = get_valid_proposal(graph, partition, pop_constraint, rng, num_tries)
@@ -222,8 +223,9 @@ function recom_chain(graph::BaseGraph,
             # go back to the previous partition
             partition = partition.parent
         end
-        scores = get_scores(graph, partition, scores, proposal)
-        push!(all_scores, scores)
+        score_vals = score_partition_from_proposal(graph, partition, proposal, scores)
+        push!(chain_scores, score_vals)
         steps_taken += 1
     end
+    return chain_scores
 end

--- a/src/scores.jl
+++ b/src/scores.jl
@@ -193,10 +193,6 @@ function get_scores_at_step(all_scores::Array{Dict{String, Any}, 1},
     score_vals = Dict{String, Any}()
     foreach(s -> score_vals[s.name] = all_scores[1][s.name], scores)
 
-    if step == 1
-        return score_vals
-    end
-
     for i in 2:step
         curr_scores = all_scores[i]
         (D₁, D₂) = all_scores[i]["dists"]

--- a/src/scores.jl
+++ b/src/scores.jl
@@ -76,9 +76,13 @@ end
 function eval_score_on_districts(graph::BaseGraph,
                                  partition::Partition,
                                  score::Union{DistrictScore,DistrictAggregate},
-                                 districts::Array{Int, 1})
+                                 districts::Array{Int, 1})::Array
     """ Evaluates a user-supplied DistrictScore function or DistrictAggregate
         score repeatedly on districts specified by the districts array.
+
+        Returns an array of the form [a₁, a₂, ..., aₙ], where aᵢ corresponds to
+        the value of the score for the district indexed by i in the `districts`
+        array and n is the length of `districts`.
     """
     return [eval_score_on_district(graph, partition, score, d) for d in districts]
 end
@@ -86,9 +90,12 @@ end
 
 function eval_score_on_partition(graph::BaseGraph,
                                  partition::Partition,
-                                 score::Union{DistrictScore,DistrictAggregate})
+                                 score::Union{DistrictScore,DistrictAggregate})::Array
     """ Evaluates a user-supplied DistrictScore function or DistrictAggregate
         score on all districts in an entire plan.
+
+        Returns an array of the form [a₁, a₂, ..., aₘ], where m is the number
+        of districts in the plan.
     """
     all_districts = Array(1:graph.num_dists)
     return eval_score_on_districts(graph, partition, score, all_districts)
@@ -210,7 +217,7 @@ end
 
 function save_scores(filename::String,
                      scores::Array{Dict{String, Any}, 1})
-    """ Save the `scores` in a JSON file named `filename`. 
+    """ Save the `scores` in a JSON file named `filename`.
     """
     open(filename, "w") do f
         JSON.print(f, scores)

--- a/src/scores.jl
+++ b/src/scores.jl
@@ -206,3 +206,13 @@ function get_scores_at_step(all_scores::Array{Dict{String, Any}, 1},
 
     return score_vals
 end
+
+
+function save_scores(filename::String,
+                     scores::Array{Dict{String, Any}, 1})
+    """ Save the `scores` in a JSON file named `filename`. 
+    """
+    open(filename, "w") do f
+        JSON.print(f, scores)
+    end
+end

--- a/src/scores.jl
+++ b/src/scores.jl
@@ -1,3 +1,30 @@
+abstract type AbstractScore end
+
+struct DistrictAggregate <: AbstractScore
+    """ A DistrictAggregate score is a simple sum of a particular property
+        over all nodes in a given district. These scores are evaluated on every
+        district in a plan.
+    """
+    name::String
+    key::String
+end
+
+struct DistrictScore <: AbstractScore
+    """ A CustomDistrictScore takes a user-supplied function that returns some
+        quantity of interest given the nodes in a given district.
+    """
+    name::String
+    score_fn::Function
+end
+
+struct PlanScore <: AbstractScore
+    """ A CustomDistrictScore takes a user-supplied function that returns some
+        quantity of interest given all the nodes in an entire plan and the
+        corresonding Partition object.
+    """
+    name::String
+    score_fn::Function
+end
 
 function initialize_dist_scores(score_keys::Array{String, 1})
     """ Initializes a Dict of the form

--- a/src/scores.jl
+++ b/src/scores.jl
@@ -179,7 +179,10 @@ function get_scores_at_step(all_scores::Array{Dict{String, Any}, 1},
                             step::Int;
                             scores::Array{S,1}=AbstractScore[]) where {S <: AbstractScore}
     """ Returns the detailed scores of the partition at step `step`. If no
-        scores are passed in, all scores are returned by default.
+        scores are passed in, all scores are returned by default. Here, step=0
+        represents the score of the original (initial) partition, so step=t
+        will return the scores of the plan that was produced after taking
+        t steps of the Markov chain.
 
         Arguments:
             all_scores : List of scores of partitions at each step of
@@ -196,9 +199,10 @@ function get_scores_at_step(all_scores::Array{Dict{String, Any}, 1},
     end
     foreach(name -> score_vals[name] = all_scores[1][name], score_names)
 
-    for i in 2:step
-        curr_scores = all_scores[i]
-        (D₁, D₂) = all_scores[i]["dists"]
+    for i in 1:step
+        # scores at index i+1 represent the scores for the plan after i steps
+        curr_scores = all_scores[i + 1]
+        (D₁, D₂) = all_scores[i + 1]["dists"]
 
         for key in score_names
             if curr_scores[key] isa Array # district-level score

--- a/test/flip.jl
+++ b/test/flip.jl
@@ -20,7 +20,12 @@
         # this is a dummy constraint
         pop_constraint = PopulationConstraint(graph, "population", 10.0)
         cont_constraint = cont_constraint = ContiguityConstraint()
-        scores = ["electionD", "electionR", "purple", "pink"]
+        scores = [
+            DistrictAggregate("electionD"),
+            DistrictAggregate("electionR"),
+            DistrictAggregate("purple"),
+            DistrictAggregate("pink"),
+        ]
         num_steps = 1000
 
         function run_chain()

--- a/test/recom.jl
+++ b/test/recom.jl
@@ -20,7 +20,12 @@
         partition = Partition(square_grid_filepath, graph, "population", "assignment")
         # this is a dummy constraint
         pop_constraint = PopulationConstraint(graph, "population", 10.0)
-        scores = ["electionD", "electionR", "purple", "pink"]
+        scores = [
+            DistrictAggregate("electionD"),
+            DistrictAggregate("electionR"),
+            DistrictAggregate("purple"),
+            DistrictAggregate("pink"),
+        ]
         num_steps = 2 # test 2 steps for now
 
         function run_chain()

--- a/test/scores.jl
+++ b/test/scores.jl
@@ -3,46 +3,175 @@
 # modified in each testset
 @testset "Score tests" begin
     graph = BaseGraph(square_grid_filepath, "population", "assignment")
-    score_keys = ["electionD", "electionR", "purple", "pink"]
+    partition = Partition(square_grid_filepath, graph, "population", "assignment")
 
-    @testset "get_scores() detailed" begin
-        partition = Partition(square_grid_filepath, graph, "population", "assignment")
-        scores = get_scores(graph, partition, score_keys, 1)
-        @test scores["num_cut_edges"] == 8
-        @test sort(scores["purple"]) == sort([28, 28, 13, 13])
-        @test sort(scores["pink"]) == sort([13, 13, 28, 28])
-        @test sort(scores["electionD"]) == sort([6, 6, 6, 6])
-        @test sort(scores["electionR"]) == sort([6, 6, 6, 6])
+    function calc_disparity(graph, nodes)
+        diff = 0
+        for node in nodes
+            diff += graph.attributes[node]["purple"]
+            diff -= graph.attributes[node]["pink"]
+        end
+        return diff
     end
 
-    @testset "get_scores() Δ" begin
-        partition = Partition(square_grid_filepath, graph, "population", "assignment")
-        proposal = RecomProposal(1,2, 51, 31, BitSet([1, 2, 3, 5, 6]), BitSet([4, 7, 8]))
+    function cut_edges(graph, partition)
+        return partition.num_cut_edges
+    end
+
+    @testset "constructors" begin
+        @test_throws MethodError DistrictAggregate("abc", 1)
+        # district scores and plan scores must take function
+        @test_throws MethodError DistrictScore("abc", "abc")
+        @test_throws MethodError PlanScore("abc", "abc")
+
+        # series of functions that will help us ensure that instantiating
+        # various scores does not result in an error
+        function create_valid_district_aggregate_1()
+            try
+                DistrictAggregate("abc")
+            catch ex
+                return ex
+            end
+        end
+
+        function create_valid_district_aggregate_2()
+            try
+                DistrictAggregate("abc", "abc")
+            catch ex
+                return ex
+            end
+        end
+
+        function create_valid_district_score()
+            try
+                DistrictScore("abc", x -> 2*x)
+            catch ex
+                return ex
+            end
+        end
+
+        function create_valid_plan_score()
+            try
+                DistrictScore("abc", x -> 2*x)
+            catch ex
+                return ex
+            end
+        end
+
+        @test !isa(create_valid_district_aggregate_1(), Exception)
+        @test !isa(create_valid_district_aggregate_2(), Exception)
+        @test !isa(create_valid_district_score(), Exception)
+        @test !isa(create_valid_plan_score(), Exception)
+    end
+
+    @testset "eval_score_on_district()" begin
+        score_race = DistrictAggregate("purple")
+        score_election_d = DistrictAggregate("electionD")
+        @test eval_score_on_district(graph, partition, score_race, 1) == 28
+        @test eval_score_on_district(graph, partition, score_election_d, 2) == 6
+
+        broken_fn = x -> 2*x # district score functions must accept graph & node array
+        bad_score = DistrictScore("break", broken_fn)
+        @test_throws MethodError eval_score_on_district(graph, partition, bad_score, 1)
+
+        race_gap = DistrictScore("race_gap", calc_disparity)
+        @test eval_score_on_district(graph, partition, race_gap, 3) == -15
+    end
+
+    @testset "eval_score_on_partition()" begin
+        score_race = DistrictAggregate("purple")
+        purples_by_district = [28, 28, 13, 13]
+        @test eval_score_on_partition(graph, partition, score_race) == purples_by_district
+        score_election_d = DistrictAggregate("electionD")
+        d_by_district = [6, 6, 6, 6]
+        @test eval_score_on_partition(graph, partition, score_election_d) == d_by_district
+
+        race_gap = DistrictScore("race_gap", calc_disparity)
+        gaps = [15, 15, -15, -15]
+        @test eval_score_on_partition(graph, partition, race_gap) == gaps
+
+        # PlanScore should take a graph & partition
+        function bad_plan_fn(x)
+            return x
+        end
+        broken_score = PlanScore("broken", bad_plan_fn)
+        @test_throws MethodError eval_score_on_partition(graph, partition, broken_score)
+
+        cut_edges_score = PlanScore("cut_edges", cut_edges)
+        @test eval_score_on_partition(graph, partition, cut_edges_score) == 8
+    end
+
+    @testset "score_initial_partition()" begin
+        scores = [
+            DistrictAggregate("purple"),
+            DistrictAggregate("pink"),
+            DistrictAggregate("electionD"),
+            DistrictAggregate("electionR"),
+            DistrictScore("race_gap", calc_disparity),
+            PlanScore("cut_edges", cut_edges)
+        ]
+
+        score_vals = score_initial_partition(graph, partition, scores)
+        @test score_vals["cut_edges"] == 8
+        @test score_vals["purple"] == [28, 28, 13, 13]
+        @test score_vals["pink"] == [13, 13, 28, 28]
+        @test score_vals["electionD"] == [6, 6, 6, 6]
+        @test score_vals["electionR"] == [6, 6, 6, 6]
+        @test score_vals["race_gap"] == [15, 15, -15, -15]
+    end
+
+    @testset "score_partition_from_proposal()" begin
+        proposal = RecomProposal(1, 2, 51, 31, BitSet([1, 2, 3, 5, 6]), BitSet([4, 7, 8]))
         update_partition!(partition, graph, proposal)
-        scores = get_scores(graph, partition, score_keys, 2, proposal)
-        @test scores["num_cut_edges"] == 9
-        @test sort(scores["purple"]) == sort([34, 22])
-        @test sort(scores["pink"]) == sort([17, 9])
-        @test sort(scores["electionD"]) == sort([8, 4])
-        @test sort(scores["electionR"]) == sort([6, 6])
+
+        scores = [
+            DistrictAggregate("purple"),
+            DistrictAggregate("pink"),
+            DistrictAggregate("electionD"),
+            DistrictAggregate("electionR"),
+            DistrictScore("race_gap", calc_disparity),
+            PlanScore("cut_edges", cut_edges)
+        ]
+
+        score_vals = score_partition_from_proposal(graph, partition, proposal, scores)
+        @test score_vals["dists"] == [1, 2]
+        @test score_vals["purple"] == [34, 22]
+        @test score_vals["pink"] == [17, 9]
+        @test score_vals["electionD"] == [8, 4]
+        @test score_vals["electionR"] == [6, 6]
+        @test score_vals["race_gap"] == [17, 13]
     end
 
     @testset "get_scores_at_step()" begin
-        partition = Partition(square_grid_filepath, graph, "population", "assignment")
         all_scores = Array{Dict{String, Any}, 1}()
-        scores = get_scores(graph, partition, score_keys, 1)
-        push!(all_scores, scores)
+        scores = [
+            DistrictAggregate("purple"),
+            DistrictAggregate("pink"),
+            DistrictAggregate("electionD"),
+            DistrictAggregate("electionR"),
+            DistrictScore("race_gap", calc_disparity),
+            PlanScore("cut_edges", cut_edges)
+        ]
+        init_score_vals = score_initial_partition(graph, partition, scores)
+        push!(all_scores, init_score_vals)
 
-        proposal = RecomProposal(1,2, 51, 31, BitSet([1, 2, 3, 5, 6]), BitSet([4, 7, 8]))
+        proposal = RecomProposal(1, 2, 51, 31, BitSet([1, 2, 3, 5, 6]), BitSet([4, 7, 8]))
+        step_score_vals = score_partition_from_proposal(graph, partition, proposal, scores)
+        push!(all_scores, step_score_vals)
+
+        parsed_scores = get_scores_at_step(all_scores, 1, scores=scores[1:2])
+        @test sort(collect(keys(parsed_scores))) == sort(["purple", "pink"])
+        for key in keys(parsed_scores)
+            @test init_score_vals[key] == parsed_scores[key]
+        end
+
+        # actually update partition and then score it
         update_partition!(partition, graph, proposal)
-        Δ_scores = get_scores(graph, partition, score_keys, 2, proposal)
-        push!(all_scores, Δ_scores)
-        detailed_scores = get_scores(graph, partition, score_keys, 1)
-
-        parsed_scores = get_scores_at_step(all_scores, 2)
-        @test keys(detailed_scores) == keys(parsed_scores)
-        for key in keys(detailed_scores)
-            @test detailed_scores[key] == parsed_scores[key]
+        updated_score_vals = score_initial_partition(graph, partition, scores)
+        parsed_scores = get_scores_at_step(all_scores, 2, scores=scores[5:6])
+        @test sort(collect(keys(parsed_scores))) == sort(["race_gap", "cut_edges"])
+        for key in keys(parsed_scores)
+            @test updated_score_vals[key] == parsed_scores[key]
         end
     end
 end

--- a/test/scores.jl
+++ b/test/scores.jl
@@ -169,21 +169,21 @@
         push!(all_scores, step_score_vals)
 
         # fetch first two scores for step 1
-        parsed_scores = get_scores_at_step(all_scores, 1, scores=scores[1:2])
+        parsed_scores = get_scores_at_step(all_scores, 0, scores=scores[1:2])
         @test sort(collect(keys(parsed_scores))) == sort(["purple", "pink"])
         for key in keys(parsed_scores)
             @test init_score_vals[key] == parsed_scores[key]
         end
 
         updated_score_vals = score_initial_partition(graph, partition, scores)
-        parsed_scores = get_scores_at_step(all_scores, 2, scores=scores[5:6])
+        parsed_scores = get_scores_at_step(all_scores, 1, scores=scores[5:6])
         @test sort(collect(keys(parsed_scores))) == sort(["race_gap", "cut_edges"])
         for key in keys(parsed_scores)
             @test updated_score_vals[key] == parsed_scores[key]
         end
 
         # passing in an empty array should yield all scores
-        parsed_scores = get_scores_at_step(all_scores, 2)
+        parsed_scores = get_scores_at_step(all_scores, 1)
         @test sort(collect(keys(parsed_scores))) == sort([s.name for s in scores])
         for key in keys(parsed_scores)
             @test updated_score_vals[key] == parsed_scores[key]

--- a/test/scores.jl
+++ b/test/scores.jl
@@ -181,5 +181,12 @@
         for key in keys(parsed_scores)
             @test updated_score_vals[key] == parsed_scores[key]
         end
+
+        # passing in an empty array should yield all scores
+        parsed_scores = get_scores_at_step(all_scores, 2)
+        @test sort(collect(keys(parsed_scores))) == sort([s.name for s in scores])
+        for key in keys(parsed_scores)
+            @test updated_score_vals[key] == parsed_scores[key]
+        end
     end
 end


### PR DESCRIPTION
At long last, I've taken a stab at implementing separate classes for district and partition-level functions! At a high level, here is how a user would instantiate an array of `Score`s that could then be passed into `flip_chain`/`recom_chain`:

```
scores = [
            DistrictAggregate("presd", "PRES12D"), # DistrictAggregate are akin to what used to be "node_attrs" - simple sums over the value of a property for all nodes in a district
            DistrictAggregate("WHITE_POP"), # by default, if only one argument is passed in, the key and name are the same
            DistrictScore("myDistrictLevelScore", fn), # fn should take a graph::BaseGraph and nodes::BitSet as arguments
            PlanScore("myPartitionLevelScore", fn2), # fn2 should take a graph::BaseGraph and partition::Partition as arguments
    ]
```

The return values of `flip_chain` and `recom_chain` are now an `Array{Dict{String, Any}, 1}`, where the entry of the array at index `i` contains the value of the scores (or delta scores) for step `i` of the chain.

Major features implemented in this pull request:
- `DistrictAggregate`, `DistrictScore`, and `PlanScore` types 
- Ability to get scores on a graph+partition and graph+updated partition+proposal
- Enforcement of function signatures for `DistrictScore`/`PlanScore`
- Comprehensive unit tests

I haven't implemented a comprehensive set of `Election` methods yet ~as I am awaiting a conversation about that~ - for a future PR!