### PR TITLE
Allow user to easily extract all values of scores at all steps in the chain

### DIFF
--- a/src/GerryChain.jl
+++ b/src/GerryChain.jl
@@ -36,7 +36,7 @@ PlanScore,
 CompositeScore,
 AbstractScore,
 score_initial_partition, score_partition_from_proposal, eval_score_on_district,
-get_scores, get_scores_at_step, eval_score_on_partition, save_scores,
+get_scores_at_step, eval_score_on_partition, save_scores, get_score_values,
 
 # acceptance functions
 always_accept, satisfies_acceptance_fn,

--- a/src/scores.jl
+++ b/src/scores.jl
@@ -344,7 +344,7 @@ end
 
 function get_score_values(all_scores::Array{Dict{String, Any}, 1},
                           composite::CompositeScore)::Dict{String, Array}
-    """ Returns the value of specified score at every step of the chain.
+    """ Returns the value of specified CompositeScore at every step of the chain.
 
         Arguments:
             all_scores  : List of scores of partitions at each step of

--- a/src/scores.jl
+++ b/src/scores.jl
@@ -314,8 +314,8 @@ function get_score_values(all_scores::Array{Dict{String, Any}, 1},
         score_table[i, :] = deepcopy(score_table[i-1, :])
         (D₁, D₂) = all_scores[i]["dists"]
         curr_scores = nested ? all_scores[i][nested_key] : all_scores[i]
-        score_table[i, D₁] = curr_scores[score.name][D₁]
-        score_table[i, D₂] = curr_scores[score.name][D₂]
+        score_table[i, D₁] = curr_scores[score.name][1]
+        score_table[i, D₂] = curr_scores[score.name][2]
     end
 
     return score_table

--- a/src/scores.jl
+++ b/src/scores.jl
@@ -290,12 +290,15 @@ end
 function get_score_values(all_scores::Array{Dict{String, Any}, 1},
                           score::Union{DistrictAggregate, DistrictScore};
                           nested_key::Union{String,Nothing}=nothing)::Array
-    """ Returns the value of specified score at every step of the chain.
+    """ Returns the value of specified DistrictScore/DistrictAggregate score
+        at every step of the chain.
 
         Arguments:
             all_scores  : List of scores of partitions at each step of
                          the Markov Chain
             score       : DistrictScore of interest
+            nested_key  : If the score is nested within a CompositeScore, this
+                          argument provides the CompositeScore's name
     """
     # check if score is nested inside a CompositeScore
     nested = nested_key == nothing
@@ -322,12 +325,14 @@ end
 function get_score_values(all_scores::Array{Dict{String, Any}, 1},
                           score::PlanScore;
                           nested_key::Union{String,Nothing}=nothing)::Array
-    """ Returns the value of specified score at every step of the chain.
+    """ Returns the value of specified PlanScore at every step of the chain.
 
         Arguments:
             all_scores  : List of scores of partitions at each step of
                          the Markov Chain
             score       : PlanScore of interest
+            nested_key  : If the score is nested within a CompositeScore, this
+                          argument provides the CompositeScore's name
     """
     num_states = length(all_scores)
     if nested_key == nothing

--- a/src/scores.jl
+++ b/src/scores.jl
@@ -301,8 +301,8 @@ function get_score_values(all_scores::Array{Dict{String, Any}, 1},
                           argument provides the CompositeScore's name
     """
     # check if score is nested inside a CompositeScore
-    nested = nested_key == nothing
-    init_vals = nested ? all_scores[1][score.name] : all_scores[1][nested_key][score.name]
+    nested = nested_key != nothing
+    init_vals = nested ? all_scores[1][nested_key][score.name] : all_scores[1][score.name]
     num_districts = length(init_vals)
     # create a matrix that is (num states of chain, num districts) to record
     # values of score
@@ -313,7 +313,7 @@ function get_score_values(all_scores::Array{Dict{String, Any}, 1},
     for i in 2:length(all_scores)
         score_table[i, :] = deepcopy(score_table[i-1, :])
         (D₁, D₂) = all_scores[i]["dists"]
-        curr_scores = nested ? all_scores[i] : all_scores[i][nested_key]
+        curr_scores = nested ? all_scores[i][nested_key] : all_scores[i]
         score_table[i, D₁] = curr_scores[score.name][D₁]
         score_table[i, D₂] = curr_scores[score.name][D₂]
     end

--- a/src/scores.jl
+++ b/src/scores.jl
@@ -329,7 +329,7 @@ function get_score_values(all_scores::Array{Dict{String, Any}, 1},
 
         Arguments:
             all_scores  : List of scores of partitions at each step of
-                         the Markov Chain
+                          the Markov Chain
             score       : PlanScore of interest
             nested_key  : If the score is nested within a CompositeScore, this
                           argument provides the CompositeScore's name
@@ -348,7 +348,7 @@ function get_score_values(all_scores::Array{Dict{String, Any}, 1},
 
         Arguments:
             all_scores  : List of scores of partitions at each step of
-                         the Markov Chain
+                          the Markov Chain
             composite   : CompositeScore of interest
     """
     fetch_vals = s -> get_score_values(all_scores, s, nested_key = composite.name)

--- a/test/scores.jl
+++ b/test/scores.jl
@@ -230,7 +230,7 @@
         step_score_vals = score_partition_from_proposal(graph, partition, proposal, scores)
         push!(all_scores, step_score_vals)
 
-        # check
+        # check that return values look correct
         purple_vals = get_score_values(all_scores, scores[1])
         @test size(purple_vals) == (2, 4)
         @test purple_vals == [[28 28 13 13]; [34 22 13 13]]


### PR DESCRIPTION
`flip_chain` and `recom_chain` return an array of Dicts that is optimized to save space by only saving information for scores that have changed at each proposal step. However, in order to analyze / plot / visualize the scores of the plans in the ensemble, there needs to be an easy way to extract all the values of the particular score(s) throughout the chain.

In this PR, I implement `get_score_values`, a function that produces an array/matrix of score values that can easily be passed into plot/visualization/summary statistic functions. The function takes in an array of `Dict`s (i.e., the return value of `flip_chain` and `recom_chain`) and an arbitrary `AbstractScore`. I take advantage of multiple dispatch to implement the method differently depending on whether a `DistrictAggregate`, `DistrictScore`, `PlanScore`, or `CompositeScore` is passed in.

_N.B._: In the future, we may change the return type of `flip_chain`/`recom_chain` to be its own type (e.g. `ScoreData`) that the user can then query for information. 

Example of usage:

```
scores = [
    PlanScore("cut_edges", count_cut_edges)
]
...
all_scores = recom_chain(graph, partition, pop_constraint, num_steps, scores)
cut_edge_arr = get_score_values(all_scores, scores[1])
```

Question: how do you feel about requiring the user to pass in the `AbstractScore` object rather than just the key? It feels _slightly_ less usable/visually appealing, but if they only pass in the key, I have to do more hacky stuff to tell whether the score was a `DistrictScore`/`PlanScore`/`CompositeScore`. For example, I have to check if the value for the key in the array of Dicts is an array (which would mean it's a `DistrictScore`/`DistrictAggregate`) or a `Dict` (which would mean it's a `CompositeScore`) or something else, which by process of elimination would mean it's a `PlanScore`. All those checks feel much uglier to write than simply using multiple dispatch, so this is what I settled on. 