### PR TITLE
ChainScoreData type

### DIFF
--- a/src/GerryChain.jl
+++ b/src/GerryChain.jl
@@ -35,6 +35,7 @@ DistrictScore,
 PlanScore,
 CompositeScore,
 AbstractScore,
+ChainScoreData,
 score_initial_partition, score_partition_from_proposal, eval_score_on_district,
 get_scores_at_step, eval_score_on_partition, save_scores, get_score_values,
 

--- a/src/flip.jl
+++ b/src/flip.jl
@@ -107,7 +107,9 @@ function flip_chain(graph::BaseGraph,
                     scores::Array{S, 1};
                     acceptance_fn::F=always_accept)::ChainScoreData where
                     {F<:Function, S<:AbstractScore}
-    """ Runs a Markov Chain for `num_steps` steps using Flip proposals.
+    """ Runs a Markov Chain for `num_steps` steps using Flip proposals. Returns
+        a ChainScoreData object which can be queried to retrieve the values of 
+        every score at each step of the chain.
 
         Arguments:
             graph:              BaseGraph

--- a/src/flip.jl
+++ b/src/flip.jl
@@ -108,7 +108,7 @@ function flip_chain(graph::BaseGraph,
                     acceptance_fn::F=always_accept)::ChainScoreData where
                     {F<:Function, S<:AbstractScore}
     """ Runs a Markov Chain for `num_steps` steps using Flip proposals. Returns
-        a ChainScoreData object which can be queried to retrieve the values of 
+        a ChainScoreData object which can be queried to retrieve the values of
         every score at each step of the chain.
 
         Arguments:
@@ -124,7 +124,7 @@ function flip_chain(graph::BaseGraph,
     """
     steps_taken = 0
     first_scores = score_initial_partition(graph, partition, scores)
-    chain_scores = ChainScoreData(scores, [first_scores])
+    chain_scores = ChainScoreData(deepcopy(scores), [first_scores])
 
     while steps_taken < num_steps
         proposal = get_valid_proposal(graph, partition, pop_constraint,

--- a/src/flip.jl
+++ b/src/flip.jl
@@ -122,7 +122,7 @@ function flip_chain(graph::BaseGraph,
     """
     steps_taken = 0
     first_scores = score_initial_partition(graph, partition, scores)
-    chain_scores = Array{Dict{String, Any}, 1}([first_scores])
+    chain_scores = ChainScoreData(scores, [first_scores])
 
     while steps_taken < num_steps
         proposal = get_valid_proposal(graph, partition, pop_constraint,
@@ -134,7 +134,7 @@ function flip_chain(graph::BaseGraph,
             partition = partition.parent
         end
         score_vals = score_partition_from_proposal(graph, partition, proposal, scores)
-        push!(chain_scores, score_vals)
+        push!(chain_scores.step_values, score_vals)
         steps_taken += 1
     end
     return chain_scores

--- a/src/flip.jl
+++ b/src/flip.jl
@@ -105,8 +105,8 @@ function flip_chain(graph::BaseGraph,
                     cont_constraint::ContiguityConstraint,
                     num_steps::Int,
                     scores::Array{S, 1};
-                    acceptance_fn::F=always_accept) where {F<:Function,
-                                                           S<:AbstractScore}
+                    acceptance_fn::F=always_accept)::ChainScoreData where
+                    {F<:Function, S<:AbstractScore}
     """ Runs a Markov Chain for `num_steps` steps using Flip proposals.
 
         Arguments:

--- a/src/recom.jl
+++ b/src/recom.jl
@@ -192,9 +192,11 @@ function recom_chain(graph::BaseGraph,
                      scores::Array{S, 1};
                      num_tries::Int=3,
                      acceptance_fn::F=always_accept,
-                     rng::AbstractRNG=Random.default_rng()) where {F<:Function,
-                                                                   S<:AbstractScore}
-    """ Runs a Markov Chain for `num_steps` steps using ReCom.
+                     rng::AbstractRNG=Random.default_rng())::ChainScoreData where
+                     {F<:Function, S<:AbstractScore}
+    """ Runs a Markov Chain for `num_steps` steps using ReCom. Returns
+        a ChainScoreData object which can be queried to retrieve the values of
+        every score at each step of the chain.
 
         Arguments:
             graph:          BaseGraph

--- a/src/recom.jl
+++ b/src/recom.jl
@@ -212,7 +212,7 @@ function recom_chain(graph::BaseGraph,
     """
     steps_taken = 0
     first_scores = score_initial_partition(graph, partition, scores)
-    chain_scores = Array{Dict{String, Any}, 1}([first_scores])
+    chain_scores = ChainScoreData(scores, [first_scores])
 
     while steps_taken < num_steps
         proposal = get_valid_proposal(graph, partition, pop_constraint, rng, num_tries)
@@ -223,7 +223,7 @@ function recom_chain(graph::BaseGraph,
             partition = partition.parent
         end
         score_vals = score_partition_from_proposal(graph, partition, proposal, scores)
-        push!(chain_scores, score_vals)
+        push!(chain_scores.step_values, score_vals)
         steps_taken += 1
     end
     return chain_scores

--- a/src/recom.jl
+++ b/src/recom.jl
@@ -214,7 +214,7 @@ function recom_chain(graph::BaseGraph,
     """
     steps_taken = 0
     first_scores = score_initial_partition(graph, partition, scores)
-    chain_scores = ChainScoreData(scores, [first_scores])
+    chain_scores = ChainScoreData(deepcopy(scores), [first_scores])
 
     while steps_taken < num_steps
         proposal = get_valid_proposal(graph, partition, pop_constraint, rng, num_tries)

--- a/src/scores.jl
+++ b/src/scores.jl
@@ -272,7 +272,7 @@ function get_scores_at_step(chain_data::ChainScoreData,
         t steps of the Markov chain.
 
         Arguments:
-            chain_data   : ChainScoreData objec tcontaining scores of partitions
+            chain_data   : ChainScoreData object containing scores of partitions
                            at each step of the Markov Chain
             step         : The step of the chain at which scores are desired
             score_names  : An optional array of Strings representing the scores
@@ -298,8 +298,8 @@ end
 function get_score_values(all_scores::Array{Dict{String, Any}, 1},
                           score::Union{DistrictAggregate, DistrictScore};
                           nested_key::Union{String,Nothing}=nothing)::Array
-    """ Returns the value of specified DistrictScore/DistrictAggregate score
-        at every step of the chain.
+    """ Helper function that returns the value of specified
+        DistrictScore/DistrictAggregate score at every step of the chain.
 
         Arguments:
             all_scores  : List of scores of partitions at each step of
@@ -333,7 +333,8 @@ end
 function get_score_values(all_scores::Array{Dict{String, Any}, 1},
                           score::PlanScore;
                           nested_key::Union{String,Nothing}=nothing)::Array
-    """ Returns the value of specified PlanScore at every step of the chain.
+    """ Helper function that returns the value of specified PlanScore at every
+        step of the chain.
 
         Arguments:
             all_scores  : List of scores of partitions at each step of
@@ -352,7 +353,8 @@ end
 
 function get_score_values(all_scores::Array{Dict{String, Any}, 1},
                           composite::CompositeScore)::Dict{String, Array}
-    """ Returns the value of specified CompositeScore at every step of the chain.
+    """ Helper function that returns the value of specified CompositeScore at
+        every step of the chain.
 
         Arguments:
             all_scores  : List of scores of partitions at each step of
@@ -364,11 +366,28 @@ function get_score_values(all_scores::Array{Dict{String, Any}, 1},
 end
 
 
+function get_score_values(chain_data::ChainScoreData,
+                          score_name::String)
+    """ Returns the value of specified score at every step of the chain.
+
+        Arguments:
+            chain_data   : ChainScoreData object containing scores of partitions
+                           at each step of the Markov Chain
+            score_name   : Name of the score of interest
+    """
+    index = findfirst(s -> s.name == score_name, chain_data.scores)
+    if index == 0
+        throw(ArgumentError("No score with requested name found."))
+    end
+    return get_score_values(chain_data.step_values, chain_data.scores[index])
+end
+
+
 function save_scores(filename::String,
-                     scores::Array{Dict{String, Any}, 1})
+                     chain_data::ChainScoreData)
     """ Save the `scores` in a JSON file named `filename`.
     """
     open(filename, "w") do f
-        JSON.print(f, scores)
+        JSON.print(f, chain_data.step_values)
     end
 end

--- a/src/scores.jl
+++ b/src/scores.jl
@@ -44,9 +44,9 @@ end
 
 struct ChainScoreData
     """ The ChainScoreData object stores the values returned by score functions
-        at every step of the chain.
+        at every step of the chain as well as the scores themselves.
     """
-    scores::Array{S,1} where {S<:AbstractScore} # should be other AbstractScores
+    scores::Array{S,1} where {S<:AbstractScore} # scores that were measured on a particular chain
     step_values::Array{Dict{String, Any}} # array of Dicts which map {score name: score value}
 end
 

--- a/src/scores.jl
+++ b/src/scores.jl
@@ -42,6 +42,15 @@ struct CompositeScore <: AbstractScore
 end
 
 
+struct ChainScoreData
+    """ The ChainScoreData object stores the values returned by score functions
+        at every step of the chain.
+    """
+    scores::Array{S,1} where {S<:AbstractScore} # should be other AbstractScores
+    step_values::Array{Dict{String, Any}} # array of Dicts which map {score name: score value}
+end
+
+
 function DistrictAggregate(key::String)
     """ Initializes a DistrictAggregate score where the name and key are
         the same.

--- a/src/scores.jl
+++ b/src/scores.jl
@@ -376,7 +376,15 @@ function get_score_values(chain_data::ChainScoreData,
             score_name   : Name of the score of interest
     """
     index = findfirst(s -> s.name == score_name, chain_data.scores)
-    if index == 0
+    if index == nothing
+        # Check if score is nested inside a CompositeScore
+        composite_scores = filter(s -> s isa CompositeScore, chain_data.scores)
+        for c in composite_scores
+            index = findfirst(s -> s.name == score_name, c.scores)
+            if index != nothing
+                return get_score_values(chain_data.step_values, c.scores[index], nested_key=c.name)
+            end
+        end
         throw(ArgumentError("No score with requested name found."))
     end
     return get_score_values(chain_data.step_values, chain_data.scores[index])

--- a/src/scores.jl
+++ b/src/scores.jl
@@ -262,9 +262,9 @@ function update_dictionary!(original::Dict{String, Any},
 end
 
 
-function get_scores_at_step(all_scores::Array{Dict{String, Any}, 1},
+function get_scores_at_step(chain_data::ChainScoreData,
                             step::Int;
-                            scores::Array{S,1}=AbstractScore[]) where {S <: AbstractScore}
+                            score_names::Array{String,1}=String[])::Dict{String, Any}
     """ Returns the detailed scores of the partition at step `step`. If no
         scores are passed in, all scores are returned by default. Here, step=0
         represents the score of the original (initial) partition, so step=t
@@ -272,23 +272,22 @@ function get_scores_at_step(all_scores::Array{Dict{String, Any}, 1},
         t steps of the Markov chain.
 
         Arguments:
-            all_scores : List of scores of partitions at each step of
-                         the Markov Chain
-            step       : The step of the chain at which scores are desired
-            scores     : An optional array of AbstractScores for which the user
-                         is requesting the values
+            chain_data   : ChainScoreData objec tcontaining scores of partitions
+                           at each step of the Markov Chain
+            step         : The step of the chain at which scores are desired
+            score_names  : An optional array of Strings representing the scores
+                           for which the user is requesting the values
     """
     # we don't want to alter the data in all_scores
     score_vals = Dict{String, Any}()
-    score_names = [s.name for s in scores]
     if isempty(score_names) # return all scores by default
-        score_names = collect(keys(all_scores[1]))
+        score_names = collect(keys(chain_data.step_values[1]))
     end
-    foreach(name -> score_vals[name] = all_scores[1][name], score_names)
+    foreach(name -> score_vals[name] = chain_data.step_values[1][name], score_names)
 
     for i in 1:step
-        curr_scores = all_scores[i + 1]
-        (D₁, D₂) = all_scores[i + 1]["dists"]
+        curr_scores = chain_data.step_values[i + 1]
+        (D₁, D₂) = chain_data.step_values[i + 1]["dists"]
         update_dictionary!(score_vals, curr_scores, D₁, D₂)
     end
 

--- a/test/scores.jl
+++ b/test/scores.jl
@@ -221,24 +221,25 @@
             PlanScore("cut_edges", cut_edges),
             CompositeScore("votes", [votes_d, votes_r])
         ]
+        chain_data = ChainScoreData(scores, [])
         # get scores for initial plan
         init_score_vals = score_initial_partition(graph, partition, scores)
-        push!(all_scores, init_score_vals)
+        push!(chain_data.step_values, init_score_vals)
 
         # generate RecomProposal, update partition, and generate new set of scores
         proposal = RecomProposal(1, 2, 51, 31, BitSet([1, 2, 3, 5, 6]), BitSet([4, 7, 8]))
         update_partition!(partition, graph, proposal)
         step_score_vals = score_partition_from_proposal(graph, partition, proposal, scores)
-        push!(all_scores, step_score_vals)
+        push!(chain_data.step_values, step_score_vals)
 
         # check that return values look correct
-        purple_vals = get_score_values(all_scores, scores[1])
+        purple_vals = get_score_values(chain_data, "purple")
         @test size(purple_vals) == (2, 4)
         @test purple_vals == [[28 28 13 13]; [34 22 13 13]]
-        cut_edge_vals = get_score_values(all_scores, scores[2])
+        cut_edge_vals = get_score_values(chain_data, "cut_edges")
         @test size(cut_edge_vals) == (2,)
         @test cut_edge_vals == [8, 9]
-        vote_vals = get_score_values(all_scores, scores[3])
+        vote_vals = get_score_values(chain_data, "votes")
         @test vote_vals isa Dict
         @test vote_vals == Dict{}("electionD" => [[6 6 6 6]; [8 4 6 6]],
                                   "electionR" => [[6 6 6 6]; [6 6 6 6]])

--- a/test/scores.jl
+++ b/test/scores.jl
@@ -243,5 +243,9 @@
         @test vote_vals isa Dict
         @test vote_vals == Dict{}("electionD" => [[6 6 6 6]; [8 4 6 6]],
                                   "electionR" => [[6 6 6 6]; [6 6 6 6]])
+        d_vote_vals = get_score_values(chain_data, "electionD")
+        @test size(d_vote_vals) == (2, 4)
+        @test d_vote_vals == [[6 6 6 6]; [8 4 6 6]]
+        @test_throws ArgumentError get_score_values(chain_data, "nonexistent")
     end
 end


### PR DESCRIPTION
This PR introduces a new type, `ChainScoreData`, which is the new return type for `recom_chain()` and `flip_chain()`. This object stores both the score functions that were measured on every plan in the chain as well as the values of the scores at every step of the chain. Introducing this new type has several benefits:

- We no longer are passing around this complex `Array{Dict{String, Any}}` object whose structure is understood only by us
- Users can now pass in the string names of scores to `get_scores_at_step` and `get_score_values` (rather than the `AbstractScore` object itself), and we can still take advantage of very clean multiple dispatch behind the scenes to handle cases where the scores requested are `DistrictScore`s vs `PlanScore`s vs `CompositeScore`s



### Usage, before change
```
scores = [
        DistrictAggregate("presd", "PRES12D"),
        DistrictAggregate("presr", "PRES12R"),
] 
...
score_values = recom_chain(graph, partition, population_constraint, num_steps, scores)
get_score_values(score_values, scores[1]) 
```

### Usage, after change
```
scores = [
        DistrictAggregate("presd", "PRES12D"),
        DistrictAggregate("presr", "PRES12R"),
] 
...
score_values = recom_chain(graph, partition, population_constraint, num_steps, scores)
get_score_values(score_values, "presd") # now you can just pass in the key of the score!
```

**PROMISE**: Once this is approved, I promise to edit the documentation appropriately and only merge once I am finished!