### PR TITLE
Add simple vote scores

### DIFF
--- a/src/GerryChain.jl
+++ b/src/GerryChain.jl
@@ -42,7 +42,7 @@ get_scores_at_step, eval_score_on_partition, save_scores, get_score_values,
 always_accept, satisfies_acceptance_fn,
 
 # election
-AbstractElection, Election, ElectionTracker, seats_won, count_votes,
+AbstractElection, Election, ElectionTracker, vote_count, vote_share, seats_won,
 mean_median, wasted_votes, efficiency_gap
 
 include("./graph.jl")

--- a/src/election.jl
+++ b/src/election.jl
@@ -51,7 +51,9 @@ function vote_count(name::String,
                    election::Election,
                    party::String)::DistrictScore
     """ TODO: write description"""
-    function score_fn(args...)
+    function score_fn(graph::BaseGraph, nodes::BitSet, district::Int)
+        party_index = findfirst(isequal(party), election.parties)
+        return election.vote_counts[district, party_index]
     end
     return DistrictScore(name, score_fn)
 end
@@ -61,7 +63,9 @@ function vote_share(name::String,
                     election::Election,
                     party::String)::DistrictScore
     """ TODO: write description"""
-    function score_fn(args...)
+    function score_fn(graph::BaseGraph, nodes::BitSet, district::Int)
+        party_index = findfirst(isequal(party), election.parties)
+        return election.vote_shares[district, party_index]
     end
     return DistrictScore(name, score_fn)
 end

--- a/src/election.jl
+++ b/src/election.jl
@@ -198,16 +198,15 @@ function ElectionTracker(election::Election,
                          scores::Array{S, 1}=AbstractScore[])::CompositeScore where {S <: AbstractScore}
     """ The ElectionTracker method returns a CompositeScore that first updates
         the vote count / share for changed districts and then proceeds to
-        calculate other partisan metrics, as desired by the user.
+        run other scores (such as vote count for a particular party, partisan
+        metrics, etc.), as desired by the user.
         Re-calculating vote counts only for changed districts means that the
         CompositeScore does not perform redundant computations for all of the
-        partisan metrics. Furthermore, packaging all partisan metrics within
-        the CompositeScore ensures that the vote update occurs first, followed
-        by the partisan metrics scoring functions.
-
-        TODO(matthew): write description of arguments
+        partisan metrics. Furthermore, packaging all election-related scores
+        within the CompositeScore ensures that the vote update occurs first,
+        followed by the partisan metrics scoring functions.
     """
     count_votes = vote_updater("votes", election) # name does not matter
-    scores = Array{AbstractScore, 1}([count_votes; partisan_metrics])
+    scores = Array{AbstractScore, 1}([count_votes; scores])
     return CompositeScore(election.name, scores)
 end

--- a/src/election.jl
+++ b/src/election.jl
@@ -16,11 +16,11 @@ function Election(name::String, parties::Array{String, 1}, num_districts::Int)
 end
 
 function vote_updater(name::String, election::Election)::DistrictScore
-    """ TODO(matthew): update description Returns a DistrictScore function that returns the vote count
-        and share for all parties in a given district. Importantly, this
-        DistrictScore function also has the side effect of updating the
-        vote counts and shares of the passed `election`, which can then be
-        used by other functions (such as seats_won, mean_median, etc.)
+    """ Returns a DistrictScore function that updates the vote counts and
+        shares of the passed `election`, which can then be used by other
+        functions (such as seats_won, mean_median, etc.) This score function
+        explicitly returns `nothing` and is meant only for internal use
+        by the ElectionTracker object.
     """
     party_names = election.parties
     function score_fn(graph::BaseGraph, nodes::BitSet, district::Int)
@@ -47,11 +47,14 @@ function vote_updater(name::String, election::Election)::DistrictScore
 end
 
 
-function vote_count(name::String,
-                   election::Election,
-                   party::String)::DistrictScore
-    """ TODO: write description"""
+function vote_count(name::String, election::Election, party::String)::DistrictScore
+    """ Returns a DistrictScore that will return the number of votes won by
+        the specified party.
+    """
     function score_fn(graph::BaseGraph, nodes::BitSet, district::Int)
+        """ Extracts the number of votes for the specified party in the 
+            specified district from the Election object.
+        """
         party_index = findfirst(isequal(party), election.parties)
         return election.vote_counts[district, party_index]
     end
@@ -59,11 +62,14 @@ function vote_count(name::String,
 end
 
 
-function vote_share(name::String,
-                    election::Election,
-                    party::String)::DistrictScore
-    """ TODO: write description"""
+function vote_share(name::String, election::Election, party::String)::DistrictScore
+    """ Returns a DistrictScore that will return the percentage of votes won by
+        the specified party.
+    """
     function score_fn(graph::BaseGraph, nodes::BitSet, district::Int)
+        """ Extracts the share of votes for the specified party in the
+            specified district from the Election object.
+        """
         party_index = findfirst(isequal(party), election.parties)
         return election.vote_shares[district, party_index]
     end
@@ -201,6 +207,7 @@ function ElectionTracker(election::Election,
 
         TODO(matthew): write description of arguments
     """
-    scores = Array{AbstractScore, 1}([vote_updater; partisan_metrics])
+    count_votes = vote_updater("votes", election) # name does not matter
+    scores = Array{AbstractScore, 1}([count_votes; partisan_metrics])
     return CompositeScore(election.name, scores)
 end

--- a/src/election.jl
+++ b/src/election.jl
@@ -15,8 +15,8 @@ function Election(name::String, parties::Array{String, 1}, num_districts::Int)
     return Election(name, parties, vote_counts, vote_shares)
 end
 
-function count_votes(name::String, election::Election)::DistrictScore
-    """ Returns a DistrictScore function that returns the vote count
+function vote_updater(name::String, election::Election)::DistrictScore
+    """ TODO(matthew): update description Returns a DistrictScore function that returns the vote count
         and share for all parties in a given district. Importantly, this
         DistrictScore function also has the side effect of updating the
         vote counts and shares of the passed `election`, which can then be
@@ -41,14 +41,27 @@ function count_votes(name::String, election::Election)::DistrictScore
         vote_totals = sum(election.vote_counts[district, :])
         vote_shares = election.vote_counts[district, :] ./ vote_totals
         election.vote_shares[district, :] = vote_shares
-        # create Dict matching party to vote count & share
-        vote_pairs = Dict{String, NamedTuple}()
-        for i in 1:length(party_names)
-            party_votes = election.vote_counts[district, i]
-            party_share = election.vote_shares[district, i]
-            vote_pairs[party_names[i]] = (vote_count=party_votes, vote_share=party_share)
-        end
-        return vote_pairs
+        return nothing
+    end
+    return DistrictScore(name, score_fn)
+end
+
+
+function vote_count(name::String,
+                   election::Election,
+                   party::String)::DistrictScore
+    """ TODO: write description"""
+    function score_fn(args...)
+    end
+    return DistrictScore(name, score_fn)
+end
+
+
+function vote_share(name::String,
+                    election::Election,
+                    party::String)::DistrictScore
+    """ TODO: write description"""
+    function score_fn(args...)
     end
     return DistrictScore(name, score_fn)
 end
@@ -172,7 +185,7 @@ end
 
 
 function ElectionTracker(election::Election,
-                         partisan_metrics::Array{S, 1}=AbstractScore[])::CompositeScore where {S <: AbstractScore}
+                         scores::Array{S, 1}=AbstractScore[])::CompositeScore where {S <: AbstractScore}
     """ The ElectionTracker method returns a CompositeScore that first updates
         the vote count / share for changed districts and then proceeds to
         calculate other partisan metrics, as desired by the user.
@@ -181,8 +194,9 @@ function ElectionTracker(election::Election,
         partisan metrics. Furthermore, packaging all partisan metrics within
         the CompositeScore ensures that the vote update occurs first, followed
         by the partisan metrics scoring functions.
+
+        TODO(matthew): write description of arguments
     """
-    vote_tracker = [count_votes("votes", election)]
-    scores = Array{AbstractScore, 1}([vote_tracker; partisan_metrics])
+    scores = Array{AbstractScore, 1}([vote_updater; partisan_metrics])
     return CompositeScore(election.name, scores)
 end

--- a/src/scores.jl
+++ b/src/scores.jl
@@ -230,7 +230,7 @@ function score_partition_from_proposal(graph::BaseGraph,
             delete!(value, "dists") # remove redundant dists key
         else # efficiently calculate & store scores only on changed districts
             value = eval_score_on_districts(graph, partition, s, Δ_districts)
-            empty_return = value[1] == nothing || value[2] == nothing
+            empty_return = any(x -> x==nothing, value)
         end
         if !empty_return
             score_values[s.name] = value

--- a/test/scores.jl
+++ b/test/scores.jl
@@ -17,6 +17,14 @@
         return partition.num_cut_edges
     end
 
+    function district_void(graph, nodes, district)
+        return nothing
+    end
+
+    function plan_void(graph, partition)
+        return nothing
+    end
+
     @testset "constructors" begin
         @test_throws MethodError DistrictAggregate("abc", 1)
         # district scores and plan scores must take function
@@ -128,7 +136,9 @@
             DistrictAggregate("pink"),
             DistrictScore("race_gap", calc_disparity),
             PlanScore("cut_edges", cut_edges),
-            CompositeScore("votes", [votes_d, votes_r])
+            CompositeScore("votes", [votes_d, votes_r]),
+            DistrictScore("d_void", district_void),
+            PlanScore("p_void", plan_void)
         ]
 
         score_vals = score_initial_partition(graph, partition, scores)
@@ -137,6 +147,8 @@
         @test score_vals["pink"] == [13, 13, 28, 28]
         @test score_vals["votes"] == Dict{}("electionD" => [6, 6, 6, 6], "electionR" => [6, 6, 6, 6])
         @test score_vals["race_gap"] == [15, 15, -15, -15]
+        @test ("d_void" in keys(score_vals)) == false
+        @test ("p_void" in keys(score_vals)) == false
     end
 
     @testset "score_partition_from_proposal()" begin


### PR DESCRIPTION
(See issue #25.) Also, **N.B.**: I've added a lot of explanatory comments, because I suspect this PR may be hard to parse!

Currently, the `ElectionTracker` object has a `DistrictScore` baked in that recalculates vote counts & vote shares for every party. This `DistrictScore` both updates the `Election` object as well as returns a `Dict` that maps party name to a tuple of vote count & vote share won by that party in a particular district. This is non-ideal, and also makes it difficult for users to easily extract the values of vote count/vote share by party from the object returned by `recom_chain()` / `flip_chain`. Furthermore, it gave no way for the user to only track vote count/share for a particular party of interest, instead forcing the user to record outcomes for all parties.

This PR splits the existing `count_votes` function (which creates a `DistrictScore` that updates the `Election` object and returns that big `Dict` of vote counts/shares) into three functions: `vote_updater` (which only updates the `Election` object and is not visible to the user), `vote_count` (which returns a `DistrictScore` that calculates the vote count for a particular party in a particular district), and `vote_share` (which returns a `DistrictScore` that calculates the vote share for a particular party in a particular district).

### Usage, before change
```
election = Election("SEN10", ["SEN10D", "SEN10R"], graph.num_dists)
election_metrics = [   # optional
    efficiency_gap("efficiency_gap", election, "SEN10D"),
    seats_won("seats_won", election, "SEN10D"),
]
...
scores = [
    ...
    ElectionTracker(election, partisan_metrics=election_metrics)
    ...
]
...
score_values = recom_chain(graph, partition, population_constraint, num_steps, scores)
# Uh oh, the votes for D are somewhere in the return object, but there's no method for me to easily retrieve it...
```

### Usage, after change
```
election = Election("SEN10", ["SEN10D", "SEN10R"], graph.num_dists)
election_metrics = [   # optional
    vote_share("share_d", election, "SEN10D"), # now user can specify what party they want to explicitly track results for!
    efficiency_gap("efficiency_gap", election, "SEN10D"),
    seats_won("seats_won", election, "SEN10D"),
]
...
scores = [
    ...
    ElectionTracker(election, election_metrics)
    ...
]
...
score_values = recom_chain(graph, partition, population_constraint, num_steps, scores)
d_share = get_score_values(score_values, "share_d") # yay! now it's easier to get this data
```

**PROMISE**: Once this is approved, I promise to edit the documentation appropriately and only merge once I am finished!