### PR TITLE
User-facing tool for plotting plan scores on histogram 

### DIFF
--- a/src/GerryChain.jl
+++ b/src/GerryChain.jl
@@ -48,7 +48,7 @@ AbstractElection, Election, ElectionTracker, vote_count, vote_share, seats_won,
 mean_median, wasted_votes, efficiency_gap,
 
 # plot
-score_boxplot
+score_boxplot, score_histogram
 
 include("./graph.jl")
 include("./partition.jl")

--- a/src/plot.jl
+++ b/src/plot.jl
@@ -127,11 +127,11 @@ end
 
 
 function score_histogram(score_values::Array{S, 1};
-                         comparison_scores::Array{Tuple{String, T},1}=[],
+                         comparison_scores::Array=[],
                          bins::Union{Nothing, Int}=nothing,
                          range::Union{Nothing,Tuple}=nothing,
                          density::Bool=false,
-                         rwidth::Union{Nothing,U}=nothing) where {S<:Number, T<:Number, U<:Number}
+                         rwidth::Union{Nothing,T}=nothing) where {S<:Number, T<:Number}
     """ Creates a graph with histogram of the values of a score throughout
         the chain. Only applicable for scores of type PlanScore.
 

--- a/src/plot.jl
+++ b/src/plot.jl
@@ -124,3 +124,27 @@ function score_boxplot(chain_data::ChainScoreData, score_name::String; kwargs...
     score_boxplot(score_vals; kwargs...)
     plt.ylabel(score_name)
 end
+
+
+function score_histogram(chain_data::ChainScoreData, score_name::String; kwargs...)
+    """ Creates a graph with histogram of the values of a score throughout
+        the chain. Only applicable for scores of type PlanScore.
+
+        Arguments:
+            chain_data  : ChainScoreData object that contains the values of
+                          scores at every step of the chain
+            score_name  : name of the score (i.e., the `name` field of an
+                          AbstractScore)
+            kwargs      : Optional arguments, including label, comparison_scores,
+                          and sort_by_score (the latter should only be passed
+                          for district-level scores).
+    """
+    score, nested_key = get_score_by_name(chain_data, score_name)
+    # throw argument error if score passed was not a PlanScore
+    if score !isa PlanScore
+        throw(ArgumentError("Can only create histogram plot of a PlanScore"))
+    end
+    score_vals = get_score_values(chain_data.step_values, score, nested_key=nested_key)
+    score_histogram(score_vals; kwargs...)
+    plt.ylabel(score_name)
+end

--- a/src/plot.jl
+++ b/src/plot.jl
@@ -131,8 +131,7 @@ function score_histogram(score_values::Array{S, 1};
                          bins::Union{Nothing, Int}=nothing,
                          range::Union{Nothing,Tuple}=nothing,
                          density::Bool=false,
-                         rwidth::Union{Nothing,U}=nothing,
-                         kwargs...) where {S<:Number, T<:Number, U<:Number}
+                         rwidth::Union{Nothing,U}=nothing) where {S<:Number, T<:Number, U<:Number}
     """ Creates a graph with histogram of the values of a score throughout
         the chain. Only applicable for scores of type PlanScore.
 
@@ -148,8 +147,6 @@ function score_histogram(score_values::Array{S, 1};
                                   where lᵢ is a label that will appear on the
                                   legend and scoreᵢ is the value of the plan-wide
                                   score for the comparison plan.
-            kwargs:               Any other arguments to matplotlib.hist that the
-                                  user wants to pass
     """
     # plot GerryChain histogram
     fig, ax = plt.subplots()
@@ -177,9 +174,8 @@ function score_histogram(chain_data::ChainScoreData, score_name::String; kwargs.
                           scores at every step of the chain
             score_name  : name of the score (i.e., the `name` field of an
                           AbstractScore)
-            kwargs      : Optional arguments, including label, comparison_scores,
-                          and sort_by_score (the latter should only be passed
-                          for district-level scores).
+            kwargs      : Optional arguments, including comparison_scores
+                          and other matplotlib arguments.
     """
     score, nested_key = get_score_by_name(chain_data, score_name)
     # throw argument error if score passed was not a PlanScore

--- a/test/plot.jl
+++ b/test/plot.jl
@@ -32,4 +32,25 @@
         @test !isa(boxplot_district_score(), Exception)
         @test !isa(boxplot_plan_score(), Exception)
     end
+
+    @testset "score_histogram()" begin
+        function histogram_no_comparison()
+            try
+                score_histogram(chain_data, "e_gap")
+            catch ex
+                return ex
+            end
+        end
+
+        function histogram_with_comparison()
+            try
+                score_histogram(chain_data, "e_gap", comparison_scores=[("abc", 0.05)])
+            catch ex
+                return ex
+            end
+        end
+        
+        @test !isa(histogram_no_comparison(), Exception)
+        @test !isa(histogram_with_comparison(), Exception)
+    end
 end


### PR DESCRIPTION
This PR makes it easy for the user to create a histogram of the values of a partition-level score throughout all steps of the chain. Also allows the user to pass in the score of particular plan(s) that they can see plotted against the histogram of the chain's score values!

## Usage
```
score = [ DistrictScore("hispanic_pop", calculate_hispanic_pop, PlanScore("cut_edges", count_cut_edges) ]

# scores for enacted plan
enacted_hispanic_pops = [323, 231, 492, 2391...]
enacted_cut_edges = 400

# run chain
chain_data = recom_chain(...)

# graph results and compare to enacted plan!
score_histogram(chain_data, "cut_edges", comparison_scores=[ ("enacted", 21) ]) # if the enacted plan has 21 cut edges
# score_histogram(chain_data, "cut_edges", comparison_scores=[ ("enacted", 21) ], bins=3, rwidth=1) # we also support passing in a few arguments that can be passed into matplotlib

# if user wants to edit anything about the default plot, they can simply use plt
plt.ylabel("Number of Cut Edges")
```

## Example histogram
![image](https://user-images.githubusercontent.com/5581093/87839677-cc5ff100-c850-11ea-84a0-af06fb215a38.png)
(Inspiration from the [MGGG Alaska report](https://mggg.org/uploads/Alaska.pdf), Figure 12 on page 27)

**PROMISE**: I will update documentation once this PR is approved!