### PR TITLE
Create simple graph from polygons

### DIFF
--- a/src/graph.jl
+++ b/src/graph.jl
@@ -87,7 +87,7 @@ function adjacency_exists(node₁_polygons::Array{LibGEOS.Polygon, 1},
     """ Returns true if there exists an adjacency between any of the polygons
         in node 1 and any of the polygons in node 2. The user provides
         an adjacency_fn (such as queen_intersection or rook_intersection) to
-        evaluate the LibGEOS.GEOSIntersection_r object.
+        evaluate the output of the LibGEOS.intersection() function.
     """
     for p₁ in node₁_polygons
         for p₂ in node₂_polygons

--- a/src/graph.jl
+++ b/src/graph.jl
@@ -81,9 +81,9 @@ function rook_intersection(intersection)::Bool
 end
 
 
-function adjacency_exists(node₁_polygons::Array{LibGEOS.Polygon, 1},
-                          node₂_polygons::Array{LibGEOS.Polygon, 1},
-                          adjacency_fn::Function)::Bool
+function adjacent(node₁_polygons::Array{LibGEOS.Polygon, 1},
+                  node₂_polygons::Array{LibGEOS.Polygon, 1},
+                  adjacency_fn::Function)::Bool
     """ Returns true if there exists an adjacency between any of the polygons
         in node 1 and any of the polygons in node 2. The user provides
         an adjacency_fn (such as queen_intersection or rook_intersection) to
@@ -101,9 +101,9 @@ function adjacency_exists(node₁_polygons::Array{LibGEOS.Polygon, 1},
 end
 
 
-function simple_graph_from_shapes(polygons::Array{Array{LibGEOS.Polygon, 1}, 1},
-                                  minimum_bounding_rects::Array{Tuple{Array{Float64,1},Array{Float64,1}},1},
-                                  adjacency::String="rook")::SimpleGraph
+function simple_graph_from_polygons(polygons::Array{Array{LibGEOS.Polygon, 1}, 1},
+                                    minimum_bounding_rects::Array{Tuple{Array{Float64,1},Array{Float64,1}},1},
+                                    adjacency::String="rook")::SimpleGraph
     """ Constructs a simple graph from polygons and the associated minimum
         bounding rectangles.
 
@@ -138,7 +138,7 @@ function simple_graph_from_shapes(polygons::Array{Array{LibGEOS.Polygon, 1}, 1},
         candidate_idxs = LibSpatialIndex.intersects(rtree, lower_left, upper_right)
         for c_idx in candidate_idxs
             # no self loops
-            if c_idx != i && !has_edge(graph, i, c_idx) && adjacency_exists(p, polygons[c_idx], adjacency_fn)
+            if c_idx != i && !has_edge(graph, i, c_idx) && adjacent(p, polygons[c_idx], adjacency_fn)
                 add_edge!(graph, i, c_idx)
             end
         end

--- a/src/graph.jl
+++ b/src/graph.jl
@@ -81,6 +81,71 @@ function rook_intersection(intersection)::Bool
 end
 
 
+function adjacency_exists(node₁_polygons::Array{LibGEOS.Polygon, 1},
+                          node₂_polygons::Array{LibGEOS.Polygon, 1},
+                          adjacency_fn::Function)::Bool
+    """ Returns true if there exists an adjacency between any of the polygons
+        in node 1 and any of the polygons in node 2. The user provides
+        an adjacency_fn (such as queen_intersection or rook_intersection) to
+        evaluate the LibGEOS.GEOSIntersection_r object.
+    """
+    for p₁ in node₁_polygons
+        for p₂ in node₂_polygons
+            intersection = LibGEOS.intersection(p₁, p₂)
+            if adjacency_fn(intersection)
+                return true
+            end
+        end
+    end
+    return false
+end
+
+
+function simple_graph_from_shapes(polygons::Array{Array{LibGEOS.Polygon, 1}, 1},
+                                  minimum_bounding_rects::Array{Tuple{Array{Float64,1},Array{Float64,1}},1},
+                                  adjacency::String="rook")::SimpleGraph
+    """ Constructs a simple graph from polygons and the associated minimum
+        bounding rectangles.
+
+        Arguments:
+
+        polygons                : Each entry in the array represents one node,
+                                  which is itself represented as an Array of
+                                  LibGEOS.Polygon objects
+        minimum_bounding_rects  : An Array of Tuples, where each tuple of
+                                  the array has the coordinates of the lower left
+                                  corner of the minimum bounding rectangle and
+                                  the coordinates of the upper left corner. The
+                                  indices of this array should match up with
+                                  the indices of the polys array.
+        adjacency               : A String that is either "queen" or "rook"
+                                  representing the style of adjacency the user
+                                  prefers.
+    """
+    if !(adjacency in ["queen", "rook"])
+        throw(ArgumentError("Adjacency must be either \"queen\" or \"rook\"."))
+    elseif length(polygons) != length(minimum_bounding_rects)
+        throw(ArgumentError("Length of polygons array must match length of minimum bounding rectangles array."))
+    end
+    adjacency_fn = adjacency == "queen" ? queen_intersection : rook_intersection
+    graph = SimpleGraph(length(polygons))
+    rtree = create_rtree(minimum_bounding_rects)
+
+    for (i, p) in enumerate(polygons)
+        # get all candidate nodes
+        lower_left = minimum_bounding_rects[i][1]
+        upper_right = minimum_bounding_rects[i][2]
+        candidate_idxs = LibSpatialIndex.intersects(rtree, lower_left, upper_right)
+        for c_idx in candidate_idxs
+            if adjacency_exists(p, polygons[c_idx], adjacency_fn)
+                add_edge!(graph, i, c_idx)
+            end
+        end
+    end
+    return graph
+end
+
+
 function read_table(filepath::AbstractString)::Shapefile.Table
     """ Read table from shapefile. If a .shp and a .dbf file of the same name
         are not found, then we throw an error.

--- a/src/graph.jl
+++ b/src/graph.jl
@@ -137,7 +137,8 @@ function simple_graph_from_shapes(polygons::Array{Array{LibGEOS.Polygon, 1}, 1},
         upper_right = minimum_bounding_rects[i][2]
         candidate_idxs = LibSpatialIndex.intersects(rtree, lower_left, upper_right)
         for c_idx in candidate_idxs
-            if adjacency_exists(p, polygons[c_idx], adjacency_fn)
+            # no self loops
+            if c_idx != i && !has_edge(graph, i, c_idx) && adjacency_exists(p, polygons[c_idx], adjacency_fn)
                 add_edge!(graph, i, c_idx)
             end
         end

--- a/test/graph.jl
+++ b/test/graph.jl
@@ -122,20 +122,20 @@ using DataStructures
         # polygon 2 and polygon 3 share a border
         # polygon 4 does not touch any other polygons
 
-        @test GerryChain.adjacency_exists([polys[1]], polys[3:4], GerryChain.queen_intersection)
-        @test !GerryChain.adjacency_exists([polys[1]], polys[3:4], GerryChain.rook_intersection)
-        @test GerryChain.adjacency_exists(polys[1:2], polys[3:4], GerryChain.queen_intersection)
-        @test GerryChain.adjacency_exists(polys[1:2], polys[3:4], GerryChain.rook_intersection)
-        @test !GerryChain.adjacency_exists(polys[1:3], [polys[4]], GerryChain.queen_intersection)
+        @test GerryChain.adjacent([polys[1]], polys[3:4], GerryChain.queen_intersection)
+        @test !GerryChain.adjacent([polys[1]], polys[3:4], GerryChain.rook_intersection)
+        @test GerryChain.adjacent(polys[1:2], polys[3:4], GerryChain.queen_intersection)
+        @test GerryChain.adjacent(polys[1:2], polys[3:4], GerryChain.rook_intersection)
+        @test !GerryChain.adjacent(polys[1:3], [polys[4]], GerryChain.queen_intersection)
     end
 
-    @testset "simple_graph_from_shapes()" begin
+    @testset "simple_graph_from_polygons()" begin
         table = GerryChain.read_table(square_shp_filepath)
         coords = GerryChain.get_node_coordinates.(table)
         node_polys = GerryChain.polygon_array.(coords)
         node_mbrs = GerryChain.min_bounding_rect.(coords)
 
-        simple_graph = GerryChain.simple_graph_from_shapes(node_polys, node_mbrs)
+        simple_graph = GerryChain.simple_graph_from_polygons(node_polys, node_mbrs)
         # there should be edges between 1 & 2, 1 & 3, 2 & 4, 3 & 4
 
         @test has_edge(simple_graph, 1, 2)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,6 +2,7 @@ using GerryChain
 import LibGEOS
 import LibSpatialIndex
 using Test
+using LightGraphs
 
 const testdir = dirname(@__FILE__)
 square_grid_filepath = "./maps/test_grid_4x4.json"


### PR DESCRIPTION
(This PR depends on #34.)

Now that we've implemented queen/rook adjacency, we can add a method that actually determines whether there is any intersection between two geographical units in the shapefile. This will be used to construct a complete `SimpleGraph` of edges and nodes. 