### PR TITLE
Create BaseGraph from .shp

### DIFF
--- a/src/graph.jl
+++ b/src/graph.jl
@@ -205,10 +205,9 @@ end
 function graph_from_shp(filepath::AbstractString,
                         pop_col::AbstractString,
                         assignment_col::AbstractString,
-                        adjacency::String="rook")
+                        adjacency::String="rook")::BaseGraph
     """ Constructs BaseGraph from .shp file.
     """
-    # TODO(matthew): change return type to BaseGraph
     table = read_table(filepath)
 
     attributes = all_node_properties(table)
@@ -217,7 +216,7 @@ function graph_from_shp(filepath::AbstractString,
     node_polys = polygon_array.(coords)
     node_mbrs = min_bounding_rect.(coords)
 
-    graph = simple_graph_from_shapes(node_polys, node_brs, adjacency)
+    graph = simple_graph_from_shapes(node_polys, node_mbrs, adjacency)
 
     # edge `i` would connect nodes edge_src[i] and edge_dst[i]
     edge_src, edge_dst = edges_from_graph(graph)
@@ -229,9 +228,9 @@ function graph_from_shp(filepath::AbstractString,
     num_districts = length(Set(assignments))
     total_pop = sum(populations)
 
-    return BaseGraph(nv(graph), ne(edges), num_districts, total_pop,
+    return BaseGraph(nv(graph), ne(graph), num_districts, total_pop,
                      populations, adj_matrix, edge_src, edge_dst, neighbors,
-                     graog, attributes)
+                     graph, attributes)
 end
 
 

--- a/src/graph.jl
+++ b/src/graph.jl
@@ -218,7 +218,20 @@ function graph_from_shp(filepath::AbstractString,
     node_mbrs = min_bounding_rect.(coords)
 
     graph = simple_graph_from_shapes(node_polys, node_brs, adjacency)
-    return nothing
+
+    # edge `i` would connect nodes edge_src[i] and edge_dst[i]
+    edge_src, edge_dst = edges_from_graph(graph)
+    # each entry in adj_matrix is the edge id that connects the two nodes
+    adj_matrix = adjacency_matrix_from_graph(graph)
+    neighbors = neighbors_from_graph(graph)
+
+    populations, assignments = get_populations_and_assignments(attributes, pop_col, assignment_col)
+    num_districts = length(Set(assignments))
+    total_pop = sum(populations)
+
+    return BaseGraph(nv(graph), ne(edges), num_districts, total_pop,
+                     populations, adj_matrix, edge_src, edge_dst, neighbors,
+                     graog, attributes)
 end
 
 

--- a/src/graph.jl
+++ b/src/graph.jl
@@ -216,7 +216,7 @@ function graph_from_shp(filepath::AbstractString,
     node_polys = polygon_array.(coords)
     node_mbrs = min_bounding_rect.(coords)
 
-    graph = simple_graph_from_shapes(node_polys, node_mbrs, adjacency)
+    graph = simple_graph_from_polygons(node_polys, node_mbrs, adjacency)
 
     # edge `i` would connect nodes edge_src[i] and edge_dst[i]
     edge_src, edge_dst = edges_from_graph(graph)

--- a/src/graph.jl
+++ b/src/graph.jl
@@ -204,7 +204,8 @@ end
 
 function graph_from_shp(filepath::AbstractString,
                         pop_col::AbstractString,
-                        assignment_col::AbstractString)
+                        assignment_col::AbstractString,
+                        adjacency::String="rook")
     """ Constructs BaseGraph from .shp file.
     """
     # TODO(matthew): change return type to BaseGraph
@@ -216,8 +217,27 @@ function graph_from_shp(filepath::AbstractString,
     node_polys = polygon_array.(coords)
     node_mbrs = min_bounding_rect.(coords)
 
-    # TODO(matthew): change return type to a Graph once we are done testing
+    graph = simple_graph_from_shapes(node_polys, node_brs, adjacency)
     return nothing
+end
+
+
+function edges_from_graph(graph::SimpleGraph)
+    """ Extract edges from graph. Returns two arrays; the first contains the
+        indices of the source nodes and the second contains the indices
+        of the destination nodes.
+    """
+    num_edges = ne(graph)
+
+    # edge `i` would connect nodes edge_src[i] and edge_dst[i]
+    edge_src = zeros(Int, num_edges)
+    edge_dst = zeros(Int, num_edges)
+
+    for (index, edge) in enumerate(edges(graph))
+        edge_src[index] = src(edge)
+        edge_dst[index] = dst(edge)
+    end
+    return edge_src, edge_dst
 end
 
 

--- a/src/graph.jl
+++ b/src/graph.jl
@@ -241,6 +241,20 @@ function edges_from_graph(graph::SimpleGraph)
 end
 
 
+function adjacency_matrix_from_graph(graph::SimpleGraph)
+    """ Extract sparse adjacency matrix from graph.
+    """
+    # each entry in adj_matrix is the edge id that connects the two nodes.
+    num_nodes = nv(graph)
+    adj_matrix = spzeros(Int, num_nodes, num_nodes)
+    for (index, edge) in enumerate(edges(graph))
+        adj_matrix[src(edge), dst(edge)] = index
+        adj_matrix[dst(edge), src(edge)] = index
+    end
+    return adj_matrix
+end
+
+
 function graph_from_json(filepath::AbstractString,
                          pop_col::AbstractString,
                          assignment_col::AbstractString)::BaseGraph
@@ -284,19 +298,12 @@ function graph_from_json(filepath::AbstractString,
     num_edges = ne(simple_graph)
 
     # edge `i` would connect nodes edge_src[i] and edge_dst[i]
-    edge_src = zeros(Int, num_edges)
-    edge_dst = zeros(Int, num_edges)
+    edge_src, edge_dst = edges_from_graph(simple_graph)
+    # each entry in adj_matrix is the edge id that connects the two nodes
+    adj_matrix = adjacency_matrix_from_graph(simple_graph)
     neighbors = [Int[] for i in 1:num_nodes, j=1]
-
-    # each entry in adj_matrix is the edge id that connects the two nodes.
-    adj_matrix = spzeros(Int, num_nodes, num_nodes)
+.
     for (index, edge) in enumerate(edges(simple_graph))
-        adj_matrix[src(edge), dst(edge)] = index
-        adj_matrix[dst(edge), src(edge)] = index
-
-        edge_src[index] = src(edge)
-        edge_dst[index] = dst(edge)
-
         push!(neighbors[src(edge)], dst(edge))
         push!(neighbors[dst(edge)], src(edge))
     end

--- a/src/graph.jl
+++ b/src/graph.jl
@@ -255,6 +255,19 @@ function adjacency_matrix_from_graph(graph::SimpleGraph)
 end
 
 
+function neighbors_from_graph(graph::SimpleGraph)
+    """ Extract each node's neighbors from graph.
+    """
+    # each entry in adj_matrix is the edge id that connects the two nodes.
+    neighbors = [ Int[] for n in 1:nv(graph) ]
+    for (index, edge) in enumerate(edges(graph))
+        push!(neighbors[src(edge)], dst(edge))
+        push!(neighbors[dst(edge)], src(edge))
+    end
+    return neighbors
+end
+
+
 function graph_from_json(filepath::AbstractString,
                          pop_col::AbstractString,
                          assignment_col::AbstractString)::BaseGraph
@@ -301,12 +314,7 @@ function graph_from_json(filepath::AbstractString,
     edge_src, edge_dst = edges_from_graph(simple_graph)
     # each entry in adj_matrix is the edge id that connects the two nodes
     adj_matrix = adjacency_matrix_from_graph(simple_graph)
-    neighbors = [Int[] for i in 1:num_nodes, j=1]
-.
-    for (index, edge) in enumerate(edges(simple_graph))
-        push!(neighbors[src(edge)], dst(edge))
-        push!(neighbors[dst(edge)], src(edge))
-    end
+    neighbors = neighbors_from_graph(simple_graph)
 
     # get attributes
     attributes = get_attributes(nodes)

--- a/src/graph.jl
+++ b/src/graph.jl
@@ -339,7 +339,8 @@ end
 
 function BaseGraph(filepath::AbstractString,
                    pop_col::AbstractString,
-                   assignment_col::AbstractString)::BaseGraph
+                   assignment_col::AbstractString;
+                   adjacency::String="rook")::BaseGraph
     """ Builds the base Graph object. This is the underlying network of our
         districts, and its properties are immutable i.e they will not change
         from step to step in our Markov Chains.
@@ -351,13 +352,16 @@ function BaseGraph(filepath::AbstractString,
                         population of that node
         assignment_col: the node attribute key whose accompanying value is the
                         assignment of that node (i.e., to a district)
+        adjacency:      (Only used if the user specifies a filepath to a .shp
+                        file.) Should be either "queen" or "rook"; "rook" by
+                        default.
     """
     extension = splitext(filepath)[2]
     try
         try
             return graph_from_json(filepath, pop_col, assignment_col)
         catch e
-            return graph_from_shp(filepath, pop_col, assignment_col)
+            return graph_from_shp(filepath, pop_col, assignment_col, adjacency)
         end
     catch
         throw(ArgumentError("Shapefile could not be processed. Please ensure the file is a valid JSON or .shp/.dbf."))

--- a/src/partition.jl
+++ b/src/partition.jl
@@ -114,7 +114,7 @@ function sample_adjacent_districts_randomly(partition::Partition,
     end
 end
 
-function get_populations_and_assignments(nodes::Array{Any, 1},
+function get_populations_and_assignments(nodes::Array,
                                          pop_col::AbstractString,
                                          assignment_col::AbstractString)
     """ Returns the arrays of populations and assignments of the graph, where

--- a/test/graph.jl
+++ b/test/graph.jl
@@ -151,6 +151,11 @@ using DataStructures
         @test graph.num_edges == 4
         @test graph.total_pop == 20
         @test graph.num_dists == 4
+
+        @test graph.populations == [2, 4, 6, 8]
+        @test graph.adj_matrix[1,2] != 0
+        @test graph.adj_matrix[1,3] != 0
+        @test graph.adj_matrix[1,4] == 0
     end
 
     graph = BaseGraph(square_grid_filepath, "population", "assignment")

--- a/test/graph.jl
+++ b/test/graph.jl
@@ -145,7 +145,7 @@ using DataStructures
         @test !has_edge(simple_graph, 2, 3)
     end
 
-    @testset "BaseGraph from shp()" begin
+    @testset "BaseGraph from shp() - rook adjacency" begin
         graph = BaseGraph(square_shp_filepath, "population", "assignment")
         @test graph.num_nodes == 4
         @test graph.num_edges == 4
@@ -153,9 +153,27 @@ using DataStructures
         @test graph.num_dists == 4
 
         @test graph.populations == [2, 4, 6, 8]
-        @test graph.adj_matrix[1,2] != 0
-        @test graph.adj_matrix[1,3] != 0
-        @test graph.adj_matrix[1,4] == 0
+        @test graph.adj_matrix[1, 2] != 0
+        @test graph.adj_matrix[1, 3] != 0
+        # upper left corner and bottom right corner should be non-adjacent
+        @test graph.adj_matrix[1, 4] == 0
+    end
+
+    @testset "BaseGraph from shp() - queen adjacency" begin
+        graph = BaseGraph(square_shp_filepath, "population", "assignment", adjacency="queen")
+        @test graph.num_nodes == 4
+        @test graph.num_edges == 6 # queen adjacency means all 6 edges
+        @test graph.total_pop == 20
+        @test graph.num_dists == 4
+
+        @test graph.populations == [2, 4, 6, 8]
+        # with queen adjacency, all squares should be adjacent to each other
+        @test graph.adj_matrix[1, 2] != 0
+        @test graph.adj_matrix[1, 3] != 0
+        @test graph.adj_matrix[1, 4] != 0
+        @test graph.adj_matrix[2, 3] != 0
+        @test graph.adj_matrix[2, 4] != 0
+        @test graph.adj_matrix[3, 4] != 0
     end
 
     graph = BaseGraph(square_grid_filepath, "population", "assignment")

--- a/test/graph.jl
+++ b/test/graph.jl
@@ -145,6 +145,14 @@ using DataStructures
         @test !has_edge(simple_graph, 2, 3)
     end
 
+    @testset "BaseGraph from shp()" begin
+        graph = BaseGraph(square_shp_filepath, "population", "assignment")
+        @test graph.num_nodes == 4
+        @test graph.num_edges == 4
+        @test graph.total_pop == 20
+        @test graph.num_dists == 4
+    end
+
     graph = BaseGraph(square_grid_filepath, "population", "assignment")
 
     @test graph.num_nodes == 16


### PR DESCRIPTION
(Depends on #35.)

This PR finally allows a user to use `BaseGraph("path/to/example.shp", POPULATION_COL, ASSIGNMENT_COL)` to instantiate a `BaseGraph` object. I also reorganize the code with three new functions (`adjacency_matrix_from_graph`, `neighbors_from_graph`, and `edges_from_graph`) that are now shared between `graph_from_json` and `graph_from_shp` (yay for non-redundancy!)