### PR TITLE
Allow nightly fail

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,3 +9,4 @@ os:
 matrix:
   allow_failures:
     - julia: nightly
+codecov: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,3 +6,6 @@ os:
   - osx
   - linux
   - windows
+matrix:
+  allow_failures:
+    - julia: nightly


### PR DESCRIPTION
Allow the nightly build to fail because it is unstable. This is what the build looks like right now, note the "This job is allowed to fail".
Also added a code coverage tool `codecov`.
<img width="501" alt="Screen Shot 2020-07-27 at 5 27 31 PM" src="https://user-images.githubusercontent.com/18491804/88594174-c0351a00-d02e-11ea-8ba9-77f9ab888846.png">
