### PR TITLE
Do not save scores with uninitialized names

### DIFF
--- a/src/election.jl
+++ b/src/election.jl
@@ -206,7 +206,7 @@ function ElectionTracker(election::Election,
         within the CompositeScore ensures that the vote update occurs first,
         followed by the partisan metrics scoring functions.
     """
-    count_votes = vote_updater(election) # name does not matter
+    count_votes = vote_updater(election)
     scores = Array{AbstractScore, 1}([count_votes; scores])
     return CompositeScore(election.name, scores)
 end

--- a/src/election.jl
+++ b/src/election.jl
@@ -15,9 +15,9 @@ function Election(name::String, parties::Array{String, 1}, num_districts::Int)
     return Election(name, parties, vote_counts, vote_shares)
 end
 
-function vote_updater(name::String, election::Election)::DistrictScore
-    """ Returns a DistrictScore function that updates the vote counts and
-        shares of the passed `election`, which can then be used by other
+function vote_updater(election::Election)::DistrictScore
+    """ Returns a nameless DistrictScore function that updates the vote counts
+        and shares of the passed `election`, which can then be used by other
         functions (such as seats_won, mean_median, etc.) This score function
         explicitly returns `nothing` and is meant only for internal use
         by the ElectionTracker object.
@@ -43,7 +43,7 @@ function vote_updater(name::String, election::Election)::DistrictScore
         election.vote_shares[district, :] = vote_shares
         return nothing
     end
-    return DistrictScore(name, score_fn)
+    return DistrictScore(score_fn)
 end
 
 
@@ -52,7 +52,7 @@ function vote_count(name::String, election::Election, party::String)::DistrictSc
         the specified party.
     """
     function score_fn(graph::BaseGraph, nodes::BitSet, district::Int)
-        """ Extracts the number of votes for the specified party in the 
+        """ Extracts the number of votes for the specified party in the
             specified district from the Election object.
         """
         party_index = findfirst(isequal(party), election.parties)
@@ -206,7 +206,7 @@ function ElectionTracker(election::Election,
         within the CompositeScore ensures that the vote update occurs first,
         followed by the partisan metrics scoring functions.
     """
-    count_votes = vote_updater("votes", election) # name does not matter
+    count_votes = vote_updater(election) # name does not matter
     scores = Array{AbstractScore, 1}([count_votes; scores])
     return CompositeScore(election.name, scores)
 end

--- a/src/scores.jl
+++ b/src/scores.jl
@@ -1,7 +1,7 @@
 abstract type AbstractScore end
 
 
-mutable struct DistrictAggregate <: AbstractScore
+struct DistrictAggregate <: AbstractScore
     """ A DistrictAggregate score is a simple sum of a particular property
         over all nodes in a given district.
     """
@@ -36,7 +36,7 @@ struct PlanScore <: AbstractScore
 end
 
 
-mutable struct CompositeScore <: AbstractScore
+struct CompositeScore <: AbstractScore
     """ A CompositeScore is just a group of scores that are run in sequence.
         CompositeScores are especially useful when the score functions depend
         upon/modify some shared state.

--- a/src/scores.jl
+++ b/src/scores.jl
@@ -308,12 +308,12 @@ function get_score_by_name(chain_data::ChainScoreData, score_name::String)
         first, the AbstractScore object itself, and second, the name of the
         CompositeScore it is nested within (if it is nested within one at all.)
     """
-    index = findfirst(s -> s.name == score_name, chain_data.scores)
+    index = findfirst(s -> isdefined(s, :name) && s.name == score_name, chain_data.scores)
     if index == nothing
         # Check if score is nested inside a CompositeScore
         composite_scores = filter(s -> s isa CompositeScore, chain_data.scores)
         for c in composite_scores
-            index = findfirst(s -> s.name == score_name, c.scores)
+            index = findfirst(s -> isdefined(s, :name) && s.name == score_name, c.scores)
             if index != nothing
                 return c.scores[index], c.name # return score and nested key
             end

--- a/src/scores.jl
+++ b/src/scores.jl
@@ -229,7 +229,6 @@ function score_partition_from_proposal(graph::BaseGraph,
     Δ_districts = [proposal.D₁, proposal.D₂]
     score_values["dists"] = Δ_districts
     for s in scores
-        value = nothing # placeholder for output of score
         if s isa PlanScore
             value = eval_score_on_partition(graph, partition, s)
         elseif s isa CompositeScore

--- a/src/scores.jl
+++ b/src/scores.jl
@@ -1,7 +1,7 @@
 abstract type AbstractScore end
 
 
-struct DistrictAggregate <: AbstractScore
+mutable struct DistrictAggregate <: AbstractScore
     """ A DistrictAggregate score is a simple sum of a particular property
         over all nodes in a given district.
     """
@@ -10,7 +10,7 @@ struct DistrictAggregate <: AbstractScore
 end
 
 
-struct DistrictScore <: AbstractScore
+mutable struct DistrictScore <: AbstractScore
     """ A DistrictScore takes a user-supplied function that returns some
         quantity of interest given the nodes in a given district. The signature
         of `score_fn` should be as follows:
@@ -18,10 +18,12 @@ struct DistrictScore <: AbstractScore
     """
     name::String
     score_fn::Function
+    DistrictScore(score_fn::Function) = (s = new(); s.score_fn = score_fn; s)
+    DistrictScore(name::String, score_fn::Function) = new(name, score_fn)
 end
 
 
-struct PlanScore <: AbstractScore
+mutable struct PlanScore <: AbstractScore
     """ A PlanScore takes a user-supplied function that returns some
         quantity of interest given a Graph and corresponding Partition object.
         The signature of `score_fn` should be as follows:
@@ -29,10 +31,12 @@ struct PlanScore <: AbstractScore
     """
     name::String
     score_fn::Function
+    PlanScore(score_fn::Function) = (s = new(); s.score_fn = score_fn; s)
+    PlanScore(name::String, score_fn::Function) = new(name, score_fn)
 end
 
 
-struct CompositeScore <: AbstractScore
+mutable struct CompositeScore <: AbstractScore
     """ A CompositeScore is just a group of scores that are run in sequence.
         CompositeScores are especially useful when the score functions depend
         upon/modify some shared state.
@@ -86,7 +90,7 @@ function eval_score_on_district(graph::BaseGraph,
     catch e # Check if the user-specified method was constructed incorrectly
         if isa(e, MethodError)
             error_msg = "DistrictScore function must accept graph, array of nodes, and district index."
-            throw(MethodError(error_msg))
+            throw(ArgumentError(error_msg))
         end
         throw(e)
     end
@@ -154,7 +158,7 @@ function eval_score_on_partition(graph::BaseGraph,
     catch e # Check if the user-specified method was constructed incorrectly
         if isa(e, MethodError)
             error_msg = "PlanScore function must accept graph and partition."
-            throw(MethodError(error_msg))
+            throw(ArgumentError(error_msg))
         end
         throw(e)
     end
@@ -192,12 +196,10 @@ function score_initial_partition(graph::BaseGraph,
     """
     score_values = Dict{String, Any}()
     for s in scores
-         value = eval_score_on_partition(graph, partition, s)
-         # check if value returned by score was empty
-         val_empty = value == nothing
-         # check if array of values returned by score was empty
-         val_empty |= (value isa Array && count(x -> x == nothing, value) == length(value))
-         val_empty ? continue : score_values[s.name] = value
+        value = eval_score_on_partition(graph, partition, s)
+        if isdefined(s, :name) # nameless scores should not be stored
+            score_values[s.name] = value
+        end
     end
     return score_values
 end
@@ -228,10 +230,8 @@ function score_partition_from_proposal(graph::BaseGraph,
     score_values["dists"] = Δ_districts
     for s in scores
         value = nothing # placeholder for output of score
-        empty_return = false # whether the score returned nothing
         if s isa PlanScore
             value = eval_score_on_partition(graph, partition, s)
-            empty_return = value == nothing
         elseif s isa CompositeScore
             # ensure that district-level scores in the CompositeScore are only
             # evaluated on changed districts
@@ -239,9 +239,8 @@ function score_partition_from_proposal(graph::BaseGraph,
             delete!(value, "dists") # remove redundant dists key
         else # efficiently calculate & store scores only on changed districts
             value = eval_score_on_districts(graph, partition, s, Δ_districts)
-            empty_return = any(x -> x==nothing, value)
         end
-        if !empty_return
+        if isdefined(s, :name)
             score_values[s.name] = value
         end
     end

--- a/test/scores.jl
+++ b/test/scores.jl
@@ -17,12 +17,12 @@
         return partition.num_cut_edges
     end
 
-    function district_void(graph, nodes, district)
-        return nothing
+    function district_void(dict)
+        return (graph, nodes, district) -> dict["district_void"] = true
     end
 
-    function plan_void(graph, partition)
-        return nothing
+    function plan_void(dict)
+        return (graph, partition) -> dict["plan_void"] = true
     end
 
     @testset "constructors" begin
@@ -93,7 +93,7 @@
 
         broken_fn = x -> 2*x # district score functions must accept graph, node array, and district index
         bad_score = DistrictScore("break", broken_fn)
-        @test_throws MethodError eval_score_on_district(graph, partition, bad_score, 1)
+        @test_throws ArgumentError eval_score_on_district(graph, partition, bad_score, 1)
 
         race_gap = DistrictScore("race_gap", calc_disparity)
         @test eval_score_on_district(graph, partition, race_gap, 3) == -15
@@ -117,7 +117,7 @@
             return x
         end
         broken_score = PlanScore("broken", bad_plan_fn)
-        @test_throws MethodError eval_score_on_partition(graph, partition, broken_score)
+        @test_throws ArgumentError eval_score_on_partition(graph, partition, broken_score)
 
         cut_edges_score = PlanScore("cut_edges", cut_edges)
         @test eval_score_on_partition(graph, partition, cut_edges_score) == 8
@@ -131,14 +131,16 @@
         partition = Partition(square_grid_filepath, graph, "population", "assignment")
         votes_d = DistrictAggregate("electionD")
         votes_r = DistrictAggregate("electionR")
+        check_done = Dict("district_void" => false, "plan_void" => false)
         scores = [
             DistrictAggregate("purple"),
             DistrictAggregate("pink"),
             DistrictScore("race_gap", calc_disparity),
             PlanScore("cut_edges", cut_edges),
             CompositeScore("votes", [votes_d, votes_r]),
-            DistrictScore("d_void", district_void),
-            PlanScore("p_void", plan_void)
+            # create nameless scores that should not be recorded by the chain
+            DistrictScore(district_void(check_done)),
+            PlanScore(plan_void(check_done))
         ]
 
         score_vals = score_initial_partition(graph, partition, scores)
@@ -149,6 +151,9 @@
         @test score_vals["race_gap"] == [15, 15, -15, -15]
         @test ("d_void" in keys(score_vals)) == false
         @test ("p_void" in keys(score_vals)) == false
+        # verify that scoring functions still ran
+        @test check_done["district_void"]
+        @test check_done["plan_void"]
     end
 
     @testset "score_partition_from_proposal()" begin


### PR DESCRIPTION
(This PR is designed to address #30, exposition copied/edited below). 

Some AbstractScores are meant to return values that get stored in the object returned by flip_chain / recom_chain. Others are simply meant to run every time a proposal is accepted (and do not return anything; e.g., the `vote_updater` function for the `ElectionTracker`. As a result, our `score_initial_partition` and `score_partition_from_proposal` functions (which return a `Dict` mapping score keys to score values) manually check whether the return type of a function is `nothing` before recording it in a `Dict`. This is messy and hard to read. Instead, these types of scores should be somehow clearly delineated in our codebase, rather than manually checking if the return type is `nothing`, which gets quite expensive.

(As a side note - this will also help with another upcoming PR to save chain scores to CSVs! It's a long story, but basically it'll make it easier to ignore the name-less score in all `Elections` that counts votes, since now I will be able to just check whether the score has the `name` property defined.)

In this PR, I allow for partially-initialized `DistrictScore`s and `PlanScore`s. These scores can be initialized with only a function and no name. In `score_initial_partition` and `score_partition_from_proposal`, I can now easily check if the name is not initialized; if so, I run the score without saving it in the `Dict`.