### PR TITLE
ChainScoreQuery iterator

### DIFF
--- a/src/scores.jl
+++ b/src/scores.jl
@@ -94,7 +94,7 @@ function Base.iterate(query::ChainScoreQuery)
             if !(haskey(score_vals, nested_key))
                 score_vals[nested_key] = Dict{String, Any}()
             end
-            score_vals[nesetd_key][score_name] = chain_data.step_values[1][nested_key][score_name]
+            score_vals[nested_key][score_name] = chain_data.step_values[1][nested_key][score_name]
         end
     end
     # keep track of next index and current dictionary

--- a/src/scores.jl
+++ b/src/scores.jl
@@ -51,6 +51,14 @@ struct ChainScoreData
 end
 
 
+struct ChainScoreQuery
+    """ Can be used to extract scores from a ChainScoreData object via an iterator
+    """
+    requested_scores::Array{S,1} where {S<:AbstractScore} # scores that were measured on a particular chain
+    chain_data::ChainScoreData
+end
+
+
 function DistrictAggregate(key::String)
     """ Initializes a DistrictAggregate score where the name and key are
         the same.

--- a/src/scores.jl
+++ b/src/scores.jl
@@ -351,8 +351,8 @@ function get_scores_at_step(chain_data::ChainScoreData,
 
     score_vals = Dict{String, Any}()
     for (i, step_scores) in enumerate(query)
-        score_vals = step_scores
         if i > step
+            score_vals = step_scores
             break
         end
     end

--- a/src/scores.jl
+++ b/src/scores.jl
@@ -69,12 +69,13 @@ end
 
 function iterate(query::ChainScoreQuery)
     # TODO(matthew): write docstring
-    if length(query.chain_data.step_values) == 0 # check that some data exists
+    chain_data = query.chain_data
+    if length(chain_data.step_values) == 0 # check that some data exists
         return nothing
     end
     # check that all requested scores are in the ChainScoreData object
     for score_name in query.requested_scores
-        score, nested_key = get_score_by_name(query.chain_data, score_name)
+        score, nested_key = get_score_by_name(chain_data, score_name)
         if score == nothing
             throw(KeyError("No score in the ChainScoreData object matches the name: $score_name"))
         end
@@ -82,10 +83,25 @@ function iterate(query::ChainScoreQuery)
 
     score_vals = Dict{String, Any}()
     if isempty(query.requested_scores) # return all scores by default
-        score_names = collect(keys(query.chain_data.step_values[1]))
+        score_names = collect(keys(chain_data.step_values[1]))
     end
     foreach(name -> score_vals[name] = chain_data.step_values[1][name], score_names)
-    return score_vals, (2, score_vals) # keep track of next index and current dictionary
+    return score_vals, (2, deepcopy(score_vals)) # keep track of next index and current dictionary
+end
+
+
+function iterate(query::ChainScoreQuery, state::Tuple)
+    # TODO(matthew): write docstring
+    step, score_vals = state
+    if step > length(query.chain_data.step_values) # end iteration
+        return nothing
+    end
+
+    chain_data = query.chain_data
+    curr_scores = chain_data.step_values[step]
+    (D₁, D₂) = chain_data.step_values[step]["dists"]
+    update_dictionary!(score_vals, curr_scores, D₁, D₂)
+    return score_vals, (step + 1, deepcopy(score_vals))
 end
 
 

--- a/src/scores.jl
+++ b/src/scores.jl
@@ -84,14 +84,17 @@ function Base.iterate(query::ChainScoreQuery)
     score_names = isempty(query.requested_scores) ? collect(keys(chain_data.step_values[1])) : query.requested_scores
     for score_name in score_names
         score, nested_key = get_score_by_name(chain_data, score_name)
-        if score == nothing
+        if isnothing(score)
             throw(KeyError("No score in the ChainScoreData object matches the name: $score_name"))
         end
         # write value to initial dictionary
-        if nested_key == nothing
+        if isnothing(nested_key)
             score_vals[score_name] = chain_data.step_values[1][score_name]
         else
-            chain_data.step_values[1][nested_key][score_name]
+            if !(haskey(score_vals, nested_key))
+                score_vals[nested_key] = Dict{String, Any}()
+            end
+            score_vals[nesetd_key][score_name] = chain_data.step_values[1][nested_key][score_name]
         end
     end
     # keep track of next index and current dictionary

--- a/src/scores.jl
+++ b/src/scores.jl
@@ -54,7 +54,7 @@ end
 struct ChainScoreQuery
     """ Can be used to extract scores from a ChainScoreData object via an iterator
     """
-    requested_scores::Array{S,1} where {S<:AbstractScore} # scores that were measured on a particular chain
+    requested_scores::Array{String,1} # scores that were measured on a particular chain
     chain_data::ChainScoreData
 end
 
@@ -64,6 +64,28 @@ function DistrictAggregate(key::String)
         the same.
     """
     return DistrictAggregate(key, key)
+end
+
+
+function iterate(query::ChainScoreQuery)
+    # TODO(matthew): write docstring
+    if length(query.chain_data.step_values) == 0 # check that some data exists
+        return nothing
+    end
+    # check that all requested scores are in the ChainScoreData object
+    for score_name in query.requested_scores
+        score, nested_key = get_score_by_name(query.chain_data, score_name)
+        if score == nothing
+            throw(KeyError("No score in the ChainScoreData object matches the name: $score_name"))
+        end
+    end
+
+    score_vals = Dict{String, Any}()
+    if isempty(query.requested_scores) # return all scores by default
+        score_names = collect(keys(query.chain_data.step_values[1]))
+    end
+    foreach(name -> score_vals[name] = chain_data.step_values[1][name], score_names)
+    return score_vals, (2, score_vals) # keep track of next index and current dictionary
 end
 
 


### PR DESCRIPTION
On my merry way to allowing users to store scores from the chain in a CSV object, I realized that I should create an iterator, where each "step" of the iterator yields a dictionary of score values at the corresponding step of the chain. This is helpful because I already kind of do that in `get_scores_at_step` and didn't want to copy/paste the code into `save_scores`. This iterator is only intended to be used internally, but if you all think it's a good API, I can also expose it to the user.

## Internal usage
```
chain_data = recom_chain(...) # pretend there's a district score called "NumPurples" and PlanScore called "cut_edges"
score_query = ChainScoreQuery(["NumPurples", "cut_edges"], chain_data)
for score_dict in score_query
    # for loop executes for the # of states there are in the chain
    # every iteration, the updated score_dict looks like Dict("NumPurples"=> ..., "cut_edges" => ...)
end
```