### PR TITLE
add codecov badge in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # GerryChainJulia
 
 [![Build Status](https://travis-ci.com/mggg/GerryChainJulia.png)](https://travis-ci.com/mggg/GerryChainJulia)
-
+[![Code Coverage](https://codecov.io/gh/mggg/GerryChainJulia/branch/main/graph/badge.svg)](https://codecov.io/gh/mggg/GerryChainJulia/branch/main)
 An implementation of our beloved GerryChain in Julia
 
 This project is under development.


### PR DESCRIPTION
Woops forgot to add the badge to the README, which I have fixed now.