### PR TITLE
Save scores as csv

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -5,6 +5,7 @@ version = "0.1.0"
 
 [deps]
 DataStructures = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"
+DelimitedFiles = "8bb1440f-4735-579b-a4ab-409b98df4dab"
 JSON = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
 LibGEOS = "a90b1aa1-3769-5649-ba7e-abc5a9d163eb"
 LibSpatialIndex = "f19c2e90-9d16-5f2d-a2a7-af3fb29e4907"

--- a/src/GerryChain.jl
+++ b/src/GerryChain.jl
@@ -5,6 +5,7 @@ using LightGraphs
 using Random
 using DataStructures
 using Statistics
+using DelimitedFiles
 using PyPlot
 import Shapefile
 import LibGEOS

--- a/src/scores.jl
+++ b/src/scores.jl
@@ -493,10 +493,8 @@ end
 function save_scores(filename::String,
                      chain_data::ChainScoreData,
                      score_names::Array{String,1}=String[])
-    """ Save the `scores` in a CSV file named `filename`. In order to avoid
-        loading all the score values into RAM (which was the point of using
-        delta scores), we instead iterate through the history of the chain
-        and write the CSV row-by-row.
+    """ Save the `scores` in a CSV file named `filename`. We iterate through
+        each state in the history of the chain and write the CSV row-by-row.
     """
     open(filename, "w") do f
         if isempty(score_names) # by default, export all scores from chain

--- a/src/scores.jl
+++ b/src/scores.jl
@@ -480,7 +480,7 @@ function district_and_plan_score_names(chain_data::ChainScoreData)::Array{String
     score_names = String[]
     for score in chain_data.scores
         if score isa CompositeScore # add children score names
-            named_scores = filter(s -> isdefined(s, :name), score.scores)
+            named_scores = filter(s -> !ismissing(s.name), score.scores)
             append!(score_names, [s.name for s in named_scores])
         else
             push!(score_names, score.name)

--- a/src/scores.jl
+++ b/src/scores.jl
@@ -472,10 +472,10 @@ function get_score_values(chain_data::ChainScoreData, score_name::String)
 end
 
 
-function district_and_plan_score_names(chain_data::ChainScoreData)::Array{String, 1}
+function flattened_score_names(chain_data::ChainScoreData)::Array{String, 1}
     """ Simple helper function for `save_scores`. Extracts the names of all of
         the district/plan-level scores (including those nested within
-        CompositeScores).
+        CompositeScores, hence the term "flattened").
     """
     score_names = String[]
     for score in chain_data.scores
@@ -498,7 +498,7 @@ function save_scores(filename::String,
     """
     open(filename, "w") do f
         if isempty(score_names) # by default, export all scores from chain
-            score_names = district_and_plan_score_names(chain_data)
+            score_names = flattened_score_names(chain_data)
         end
 
         column_names = String[] # colum names of the CSV


### PR DESCRIPTION
(N.B. This PR depends on #40 and #39, so the branch I'm asking to merge into is a Frankenstein of PR #39 and #40 so that the commit history of this PR looks right. I'll be sure to double check when I merge things into `main` that I don't run into any weird git errors.)

This method allows the user to easily save the scores of their choosing in a file with a CSV format. The main issue with saving as a JSON was that (a) we were saving the delta score format (which no one understands besides us) and (b) if we wanted to save the raw value of every score at every step, we would have to load all those values into RAM...which defeats the purpose of the delta score.

Enter CSVs! We can write to a CSV line by line, so we only have to be able to load in the score values for a particular state of the chain to write a single row, rather than all score values at all states.

## Usage 
```
chain_data = recom_chain(graph, partition, pop_constraint, 10, scores)
save_scores("test.csv", chain_data) # by default will save all scores in the chain
# alternatively, save_scores("test.csv", chain_data, ["names", "of", "desired", "scores"])
```

## Result
![image](https://user-images.githubusercontent.com/5581093/88605412-ab588680-d02e-11ea-90ab-cbc8bdf4b7c1.png)
(Notice how district-level scores are automatically "expanded" such that each district has its own column. I'll make sure to note in the documentation that the district index doesn't really mean anything.)

**N.B.** I promise to update the documentation before merging in this PR!