### PR TITLE
Change API for Partition constructor to only require a BaseGraph and assignment column

### DIFF
--- a/src/graph.jl
+++ b/src/graph.jl
@@ -196,6 +196,9 @@ end
 
 
 function population_to_int(raw_value::Number)::Int
+    """ Tiny helper function to coerce population counts (whether they are
+        ints or floats) to int.
+    """
     return raw_value isa Int ? raw_value : convert(Int, round(raw_value))
 end
 

--- a/src/partition.jl
+++ b/src/partition.jl
@@ -8,10 +8,7 @@ mutable struct Partition
     parent::Union{Partition, Nothing}           # optional parent partition
 end
 
-function Partition(filepath::AbstractString,
-                   graph::BaseGraph,
-                   pop_col::AbstractString,
-                   assignment_col::AbstractString)::Partition
+function Partition(graph::BaseGraph, assignment_col::AbstractString)::Partition
 
     """
         Partition represents a partition of the nodes of the graph.
@@ -25,9 +22,8 @@ function Partition(filepath::AbstractString,
             pop_col:   the key denoting the population attribute at the node level
             assignment_col: the key denoting the district assignment at the node level
     """
-    raw_graph = JSON.parsefile(filepath)
-
-    populations, assignments = get_populations_and_assignments(raw_graph["nodes"], pop_col, assignment_col)
+    populations =  graph.populations
+    assignments = extract_attribute(graph.attributes, assignment_col, process_assignment)
 
     # get cut_edges, district_adjacencies
     dist_adj, cut_edges = get_district_adj_and_cut_edges(graph, assignments, graph.num_dists)
@@ -112,26 +108,6 @@ function sample_adjacent_districts_randomly(partition::Partition,
             return D₁, D₂
         end
     end
-end
-
-function get_populations_and_assignments(nodes::Array,
-                                         pop_col::AbstractString,
-                                         assignment_col::AbstractString)
-    """ Returns the arrays of populations and assignments of the graph, where
-        i'th node's population is populations[i] and assignment is assignments[i].
-    """
-    num_nodes = length(nodes)
-    populations = zeros(Int, num_nodes)
-    assignments = zeros(Int, num_nodes)
-    for i in 1:num_nodes
-        populations[i] = nodes[i][pop_col]
-        if nodes[i][assignment_col] isa String
-            assignments[i] = parse(Int, nodes[i][assignment_col])
-        elseif nodes[i][assignment_col] isa Int
-            assignments[i] = nodes[i][assignment_col]
-        end
-    end
-    return populations, assignments
 end
 
 

--- a/src/partition.jl
+++ b/src/partition.jl
@@ -23,7 +23,7 @@ function Partition(graph::BaseGraph, assignment_col::AbstractString)::Partition
             assignment_col: the key denoting the district assignment at the node level
     """
     populations =  graph.populations
-    assignments = extract_attribute(graph.attributes, assignment_col, process_assignment)
+    assignments = get_assignments(graph.attributes, assignment_col)
 
     # get cut_edges, district_adjacencies
     dist_adj, cut_edges = get_district_adj_and_cut_edges(graph, assignments, graph.num_dists)

--- a/test/accept.jl
+++ b/test/accept.jl
@@ -1,6 +1,6 @@
 @testset "satisfies_acceptance_fn" begin
     graph = BaseGraph(square_grid_filepath, "population", "assignment")
-    partition = Partition(square_grid_filepath, graph, "population", "assignment")
+    partition = Partition(graph, "assignment")
 
     inval_acc_fn_1(p) = "hi"
     inval_acc_fn_2(p) = -3

--- a/test/constraints.jl
+++ b/test/constraints.jl
@@ -19,7 +19,7 @@ end
 
 @testset "Contiguity Constraint" begin
     graph = BaseGraph(cols_grid_filepath, "population", "assignment")
-    partition = Partition(cols_grid_filepath, graph, "population", "assignment")
+    partition = Partition(graph, "assignment")
     cont_constraint = ContiguityConstraint()
     discont_proposal = FlipProposal(5, 1, 0, 30, 42,
                                     BitSet([1, 9, 13]),

--- a/test/election.jl
+++ b/test/election.jl
@@ -14,7 +14,7 @@
 
     @testset "vote_updater()" begin
         graph = BaseGraph(square_grid_filepath, "population", "assignment")
-        partition = Partition(square_grid_filepath, graph, "population", "assignment")
+        partition = Partition(graph, "assignment")
         election = Election("Test Election", ["electionD", "electionR"], graph.num_dists)
         election_tracker = ElectionTracker(election)
 
@@ -27,7 +27,7 @@
 
     @testset "vote_count()" begin
         graph = BaseGraph(square_grid_filepath, "population", "assignment")
-        partition = Partition(square_grid_filepath, graph, "population", "assignment")
+        partition = Partition(graph, "assignment")
         election = Election("Test Election", ["electionD", "electionR"], graph.num_dists)
 
         d_count = vote_count("votes_d", election, "electionD")
@@ -46,7 +46,7 @@
 
     @testset "vote_share()" begin
         graph = BaseGraph(square_grid_filepath, "population", "assignment")
-        partition = Partition(square_grid_filepath, graph, "population", "assignment")
+        partition = Partition(graph, "assignment")
         election = Election("Test Election", ["electionD", "electionR"], graph.num_dists)
 
         d_share = vote_share("share_d", election, "electionD")
@@ -65,7 +65,7 @@
 
     @testset "seats_won()" begin
         graph = BaseGraph(square_grid_filepath, "population", "assignment")
-        partition = Partition(square_grid_filepath, graph, "population", "assignment")
+        partition = Partition(graph, "assignment")
         election = Election("Test Election", ["electionD", "electionR"], graph.num_dists)
         election_tracker = ElectionTracker(election)
         update_vote_counts(graph, partition, election_tracker)
@@ -101,7 +101,7 @@
 
     @testset "mean_median()" begin
         graph = BaseGraph(square_grid_filepath, "population", "assignment")
-        partition = Partition(square_grid_filepath, graph, "population", "assignment")
+        partition = Partition(graph, "assignment")
         election = Election("Test Election", ["electionD", "electionR"], graph.num_dists)
         election_tracker = ElectionTracker(election)
         update_vote_counts(graph, partition, election_tracker)
@@ -144,7 +144,7 @@
         graph.attributes[9]["electionD"] = 4
         graph.attributes[11]["electionD"] = 4
 
-        partition = Partition(square_grid_filepath, graph, "population", "assignment")
+        partition = Partition(graph, "assignment")
         election = Election("Test Election", ["electionD", "electionR"], graph.num_dists)
         election_tracker = ElectionTracker(election)
         update_vote_counts(graph, partition, election_tracker)
@@ -166,7 +166,7 @@
 
     @testset "ElectionTracker updates votes" begin
         graph = BaseGraph(square_grid_filepath, "population", "assignment")
-        partition = Partition(square_grid_filepath, graph, "population", "assignment")
+        partition = Partition(graph, "assignment")
         election = Election("Test Election", ["electionD", "electionR"], graph.num_dists)
         election_tracker = ElectionTracker(election)
         update_vote_counts(graph, partition, election_tracker)

--- a/test/flip.jl
+++ b/test/flip.jl
@@ -1,6 +1,6 @@
 @testset "Flip tests" begin
     graph = BaseGraph(square_grid_filepath, "population", "assignment")
-    partition = Partition(square_grid_filepath, graph, "population", "assignment")
+    partition = Partition(graph, "assignment")
 
     @testset "propose_random_flip()" begin
         flip_prop = GerryChain.propose_random_flip(graph, partition)

--- a/test/partition.jl
+++ b/test/partition.jl
@@ -33,7 +33,7 @@
 # partition tests
 @testset "Partition tests" begin
     graph = BaseGraph(square_grid_filepath, "population", "assignment")
-    partition = Partition(square_grid_filepath, graph, "population", "assignment")
+    partition = Partition(graph, "assignment")
 
     @test partition.num_cut_edges == 8
     @test partition.dist_populations[1] == 41

--- a/test/recom.jl
+++ b/test/recom.jl
@@ -17,7 +17,7 @@
     end
 
     @testset "recom_chain()" begin
-        partition = Partition(square_grid_filepath, graph, "population", "assignment")
+        partition = Partition(graph, "assignment")
         # this is a dummy constraint
         pop_constraint = PopulationConstraint(graph, "population", 10.0)
         scores = [

--- a/test/scores.jl
+++ b/test/scores.jl
@@ -85,7 +85,7 @@
     end
 
     @testset "eval_score_on_district()" begin
-        partition = Partition(square_grid_filepath, graph, "population", "assignment")
+        partition = Partition(graph, "assignment")
         score_race = DistrictAggregate("purple")
         score_election_d = DistrictAggregate("electionD")
         @test eval_score_on_district(graph, partition, score_race, 1) == 28
@@ -100,7 +100,7 @@
     end
 
     @testset "eval_score_on_partition()" begin
-        partition = Partition(square_grid_filepath, graph, "population", "assignment")
+        partition = Partition(graph, "assignment")
         score_race = DistrictAggregate("purple")
         purples_by_district = [28, 28, 13, 13]
         @test eval_score_on_partition(graph, partition, score_race) == purples_by_district
@@ -128,7 +128,7 @@
     end
 
     @testset "score_initial_partition()" begin
-        partition = Partition(square_grid_filepath, graph, "population", "assignment")
+        partition = Partition(graph, "assignment")
         votes_d = DistrictAggregate("electionD")
         votes_r = DistrictAggregate("electionR")
         scores = [
@@ -152,7 +152,7 @@
     end
 
     @testset "score_partition_from_proposal()" begin
-        partition = Partition(square_grid_filepath, graph, "population", "assignment")
+        partition = Partition(graph, "assignment")
         # create RecomProposal
         proposal = RecomProposal(1, 2, 51, 31, BitSet([1, 2, 3, 5, 6]), BitSet([4, 7, 8]))
         update_partition!(partition, graph, proposal)
@@ -177,7 +177,7 @@
     end
 
     @testset "get_scores_at_step()" begin
-        partition = Partition(square_grid_filepath, graph, "population", "assignment")
+        partition = Partition(graph, "assignment")
         # initialize scores
         votes_d = DistrictAggregate("electionD")
         votes_r = DistrictAggregate("electionR")
@@ -223,7 +223,7 @@
     end
 
     @testset "get_score_values()" begin
-        partition = Partition(square_grid_filepath, graph, "population", "assignment")
+        partition = Partition(graph, "assignment")
         # initialize scores
         all_scores = Array{Dict{String, Any}, 1}()
         votes_d = DistrictAggregate("electionD")


### PR DESCRIPTION
(Depends on #36.)

Since all the node attributes are stored in the `BaseGraph` object, there is no need for the `Partition` object to require that the user pass in a path to a `JSON` file. I alter the `Partition` constructor to only require the `BaseGraph` and the string key for the assignment attribute. Now we can finally run chains using Shapefiles! 🎊🎊🎊

## Example
```
graph = BaseGraph("./UT_precincts/UT_precincts.shp", "TOTPOP", "CountyID")
partition = Partition(graph, "CountyID")
...
chain_data = recom_chain(graph, partition, pop_constraint, 10, scores)
```

## Result
![image](https://user-images.githubusercontent.com/5581093/88718220-7e5fae80-d0d6-11ea-8ded-12fe1e3d540e.png)


## Changes in PR
* Removing `get_populations_and_assignments` and replacing with a more general `get_attribute_by_key` method
* Alter `Partition` constructor 
* Modify tests now that the `Partition` constructor has changed

**PROMISE**: I will update the documentation after this PR has been accepted before I merge it!