### PR TITLE
Add simple score to count number of cut edges

### DIFF
--- a/src/GerryChain.jl
+++ b/src/GerryChain.jl
@@ -43,6 +43,7 @@ AbstractScore,
 ChainScoreData,
 score_initial_partition, score_partition_from_proposal, eval_score_on_district,
 get_scores_at_step, eval_score_on_partition, save_scores, get_score_values,
+num_cut_edges,
 
 # acceptance functions
 always_accept, satisfies_acceptance_fn,

--- a/src/scores.jl
+++ b/src/scores.jl
@@ -550,3 +550,14 @@ function save_scores(filename::String,
         end
     end
 end
+
+
+function num_cut_edges(name::String)::PlanScore
+    """ Returns a PlanScore that tracks the number of cut edges in a particular
+        plan.
+    """
+    function score_fn(graph::BaseGraph, partition::Partition)
+        return partition.num_cut_edges
+    end
+    return PlanScore(name, score_fn)
+end

--- a/test/scores.jl
+++ b/test/scores.jl
@@ -13,10 +13,6 @@
         return diff
     end
 
-    function cut_edges(graph, partition)
-        return partition.num_cut_edges
-    end
-
     function district_void(dict)
         return (graph, nodes, district) -> dict["district_void"] = true
     end
@@ -119,7 +115,7 @@
         broken_score = PlanScore("broken", bad_plan_fn)
         @test_throws ArgumentError eval_score_on_partition(graph, partition, broken_score)
 
-        cut_edges_score = PlanScore("cut_edges", cut_edges)
+        cut_edges_score = num_cut_edges("cut_edges")
         @test eval_score_on_partition(graph, partition, cut_edges_score) == 8
 
         group_score = CompositeScore("group", Array{AbstractScore, 1}([race_gap, cut_edges_score]))
@@ -136,7 +132,7 @@
             DistrictAggregate("purple"),
             DistrictAggregate("pink"),
             DistrictScore("race_gap", calc_disparity),
-            PlanScore("cut_edges", cut_edges),
+            num_cut_edges("cut_edges"),
             CompositeScore("votes", [votes_d, votes_r]),
             # create nameless scores that should not be recorded by the chain
             DistrictScore(district_void(check_done)),
@@ -168,7 +164,7 @@
             DistrictAggregate("purple"),
             DistrictAggregate("pink"),
             DistrictScore("race_gap", calc_disparity),
-            PlanScore("cut_edges", cut_edges),
+            num_cut_edges("cut_edges"),
             CompositeScore("votes", [votes_d, votes_r])
         ]
 
@@ -190,7 +186,7 @@
             DistrictAggregate("purple"),
             DistrictAggregate("pink"),
             DistrictScore("race_gap", calc_disparity),
-            PlanScore("cut_edges", cut_edges),
+            num_cut_edges("cut_edges"),
             CompositeScore("votes", [votes_d, votes_r])
         ]
         chain_data = ChainScoreData(scores, [])
@@ -235,7 +231,7 @@
         votes_r = DistrictAggregate("electionR")
         scores = [
             DistrictAggregate("purple"),
-            PlanScore("cut_edges", cut_edges),
+            num_cut_edges("cut_edges"),
             CompositeScore("votes", [votes_d, votes_r])
         ]
         chain_data = ChainScoreData(scores, [])


### PR DESCRIPTION
Pretty self-explanatory! This PR will allow us to close #25. It adds an easy-to-use function where users pass in a `String` representing the name of the score and a `PlanScore` is returned.

# Usage
```
scores = [
    ...
    num_cut_edges("cut_edges")
]
data = recom_chain(..., scores)
```

**PROMISE**: I will update the documentation to include this new score soon!