### PR TITLE
Allow user to specify location of legend in plot functions

### DIFF
--- a/src/plot.jl
+++ b/src/plot.jl
@@ -1,7 +1,8 @@
 function score_boxplot(score_values::Array{S, 2};
                        sort_by_score::Bool=true,
                        label::String="GerryChain",
-                       comparison_scores::Array=[]) where {S<:Number}
+                       comparison_scores::Array=[],
+                       bbox_to_anchor::Union{Nothing, Tuple}=nothing) where {S<:Number}
     """ Produces a graph with multiple matplotlib box plots for the values of
         scores throughout the chain. Intended for use with district-level scores
         (DistrictAggregate, DistrictScore).
@@ -57,14 +58,19 @@ function score_boxplot(score_values::Array{S, 2};
             plan_score_vals = sort_by_score ? sort(p[2]) : p[2]
             plt.scatter(1:length(p[2]), plan_score_vals, label=p[1])
         end
-        plt.legend()
+        if !isnothing(bbox_to_anchor)
+            plt.legend(bbox_to_anchor=bbox_to_anchor)
+        else
+            plt.legend()
+        end
     end
 end
 
 
 function score_boxplot(score_values::Array{S, 1};
                        label::String="GerryChain",
-                       comparison_scores::Array=[]) where {S<:Number}
+                       comparison_scores::Array=[],
+                       bbox_to_anchor::Union{Nothing, Tuple}=nothing) where {S<:Number}
     """ Produces a single matplotlib box plot for the values of scores
         throughout the chain. Intended for use with plan-level scores.
 
@@ -98,7 +104,11 @@ function score_boxplot(score_values::Array{S, 1};
             end
             plt.scatter(1, p[2], label=p[1])
         end
-        plt.legend()
+        if !isnothing(bbox_to_anchor)
+            plt.legend(bbox_to_anchor=bbox_to_anchor)
+        else
+            plt.legend()
+        end
     end
 end
 
@@ -129,9 +139,10 @@ end
 function score_histogram(score_values::Array{S, 1};
                          comparison_scores::Array=[],
                          bins::Union{Nothing, Int}=nothing,
-                         range::Union{Nothing,Tuple}=nothing,
+                         range::Union{Nothing, Tuple}=nothing,
                          density::Bool=false,
-                         rwidth::Union{Nothing,T}=nothing) where {S<:Number, T<:Number}
+                         rwidth::Union{Nothing, T}=nothing,
+                         bbox_to_anchor::Union{Nothing, Tuple}=nothing) where {S<:Number, T<:Number}
     """ Creates a graph with histogram of the values of a score throughout
         the chain. Only applicable for scores of type PlanScore.
 
@@ -160,7 +171,11 @@ function score_histogram(score_values::Array{S, 1};
             ax.axvline(p[2], color=color, label=p[1])
             color_index += 1
         end
-        ax.legend()
+        if !isnothing(bbox_to_anchor)
+            plt.legend(bbox_to_anchor=bbox_to_anchor)
+        else
+            plt.legend()
+        end
     end
 end
 

--- a/src/plot.jl
+++ b/src/plot.jl
@@ -58,11 +58,7 @@ function score_boxplot(score_values::Array{S, 2};
             plan_score_vals = sort_by_score ? sort(p[2]) : p[2]
             plt.scatter(1:length(p[2]), plan_score_vals, label=p[1])
         end
-        if !isnothing(bbox_to_anchor)
-            plt.legend(bbox_to_anchor=bbox_to_anchor)
-        else
-            plt.legend()
-        end
+        isnothing(bbox_to_anchor) ? plt.legend() : plt.legend(bbox_to_anchor=bbox_to_anchor)  
     end
 end
 
@@ -104,11 +100,7 @@ function score_boxplot(score_values::Array{S, 1};
             end
             plt.scatter(1, p[2], label=p[1])
         end
-        if !isnothing(bbox_to_anchor)
-            plt.legend(bbox_to_anchor=bbox_to_anchor)
-        else
-            plt.legend()
-        end
+        isnothing(bbox_to_anchor) ? plt.legend() : plt.legend(bbox_to_anchor=bbox_to_anchor)
     end
 end
 
@@ -171,11 +163,7 @@ function score_histogram(score_values::Array{S, 1};
             ax.axvline(p[2], color=color, label=p[1])
             color_index += 1
         end
-        if !isnothing(bbox_to_anchor)
-            plt.legend(bbox_to_anchor=bbox_to_anchor)
-        else
-            plt.legend()
-        end
+        isnothing(bbox_to_anchor) ? plt.legend() : plt.legend(bbox_to_anchor=bbox_to_anchor)
     end
 end
 

--- a/test/plot.jl
+++ b/test/plot.jl
@@ -29,8 +29,31 @@
             end
         end
 
+        function boxplot_plan_score_with_comparison()
+            try
+                score_boxplot(chain_data, "e_gap", comparison_scores=[("a", 0)])
+            catch ex
+                return ex
+            end
+        end
+
+        function boxplot_plan_score_with_custom_legend()
+            try
+                score_boxplot(
+                    chain_data,
+                    "e_gap",
+                    comparison_scores=[("a", 0)],
+                    bbox_to_anchor=(0.5, 0.5)
+                )
+            catch ex
+                return ex
+            end
+        end
+
         @test !isa(boxplot_district_score(), Exception)
         @test !isa(boxplot_plan_score(), Exception)
+        @test !isa(boxplot_plan_score_with_comparison(), Exception)
+        @test !isa(boxplot_plan_score_with_custom_legend(), Exception)
     end
 
     @testset "score_histogram()" begin
@@ -50,7 +73,21 @@
             end
         end
 
+        function histogram_with_custom_legend()
+            try
+                score_histogram(
+                    chain_data,
+                    "e_gap",
+                    comparison_scores=[("abc", 0.05)],
+                    bbox_to_anchor=(0.5, 0.5)
+                )
+            catch ex
+                return ex
+            end
+        end
+
         @test !isa(histogram_no_comparison(), Exception)
         @test !isa(histogram_with_comparison(), Exception)
+        @test !isa(histogram_with_custom_legend(), Exception)
     end
 end


### PR DESCRIPTION
Addresses issue #52.

# Usage
```
score_boxplot(chain_data, "dem_vote_share", comparison_scores=[("plan1", plan1_bwratios), ("plan2", plan2_bwratios)], bbox_to_anchor=(0.5, 0.5))
score_histogram(chain_data, "efficiency_gap", rwidth=1, bins=6, comparison_scores=[("mean", 0.1), ("mean2", 0.06)], bbox_to_anchor=(0.5, 0.5))
```

# Result
![image](https://user-images.githubusercontent.com/5581093/90171920-1c01e180-dd57-11ea-9894-2eca421164bf.png)
![image](https://user-images.githubusercontent.com/5581093/90170879-7dc14c00-dd55-11ea-9bec-759fab2aa8c9.png)
