### PR TITLE
Throw error when assignment column could not be processed

### DIFF
--- a/src/graph.jl
+++ b/src/graph.jl
@@ -95,8 +95,8 @@ function get_assignments(node_attributes::Array,
             end
         else
             message = """
-                District assignments should be Ints or Strings; instead,
-                type $(typeof(raw_value)) was found instead.
+                District assignments should be Ints or Strings; type
+                $(typeof(raw_value)) was found instead.
             """
             throw(DomainError(raw_value, message))
         end

--- a/src/graph.jl
+++ b/src/graph.jl
@@ -93,6 +93,12 @@ function get_assignments(node_attributes::Array,
                 end
                 processed_assignments[i] = assignment_to_num[raw_value]
             end
+        else
+            message = """
+                District assignments should be Ints or Strings; instead,
+                type $(typeof(raw_value)) was found instead.
+            """
+            throw(DomainError(raw_value, message))
         end
     end
     return processed_assignments

--- a/test/graph.jl
+++ b/test/graph.jl
@@ -53,6 +53,13 @@ using DataStructures
         @test node_attributes == correct_attributes
     end
 
+    @testset "Check type of district assignments - get_assignments()" begin
+        graph = BaseGraph(square_shp_filepath, "population", "assignment")
+        # assignment that is a Float should throw an error
+        foreach(d -> d["assignment"] *= 1.0, graph.attributes) # convert Int to Float
+        @test_throws DomainError GerryChain.get_assignments(graph.attributes, "assignment")
+    end
+
     @testset "BaseGraph from shp() - rook adjacency" begin
         graph = BaseGraph(square_shp_filepath, "population", "assignment")
         @test graph.num_nodes == 4


### PR DESCRIPTION
(See Issue #51 for more context.)

# Description
Currently, when users read in a JSON, we check if the assignment column is an `Int` or a `String` and parse it appropriately. *However*, when it is *neither an `Int` nor a `String`, we don't emit any error and instead just store all the assignments as `0`! This is definitely wrong and users have fed in shapefiles to the `BaseGraph` constructor method unaware that the type of the assignment column was wrong and then been confused as to why their code was hitting an error. 

# Screenshot of error
![image](https://user-images.githubusercontent.com/5581093/90176212-79009600-dd5d-11ea-96eb-9ad1818c15b9.png)
