### PR TITLE
Modify how error handling works for reading in JSON/.shp files to be more user-friendly

### DIFF
--- a/src/graph.jl
+++ b/src/graph.jl
@@ -93,6 +93,12 @@ function get_assignments(node_attributes::Array,
                 end
                 processed_assignments[i] = assignment_to_num[raw_value]
             end
+        else
+            message = """
+                District assignments should be Ints or Strings; instead,
+                type $(typeof(raw_value)) was found instead.
+            """
+            throw(DomainError(raw_value, message))
         end
     end
     return processed_assignments
@@ -281,15 +287,13 @@ function BaseGraph(filepath::AbstractString,
                         file.) Should be either "queen" or "rook"; "rook" by
                         default.
     """
-    extension = splitext(filepath)[2]
-    try
-        try
-            return graph_from_json(filepath, pop_col, assignment_col)
-        catch e
-            return graph_from_shp(filepath, pop_col, assignment_col, adjacency)
-        end
-    catch
-        throw(ArgumentError("Shapefile could not be processed. Please ensure the file is a valid JSON or .shp/.dbf."))
+    extension = uppercase(splitext(filepath)[2])
+    if uppercase(extension) == ".JSON"
+        return graph_from_json(filepath, pop_col, assignment_col)
+    elseif uppercase(extension) == ".SHP"
+        return graph_from_shp(filepath, pop_col, assignment_col, adjacency)
+    else
+        throw(DomainError(filepath, "Filepath must lead to valid JSON file or valid .shp/.dbf file."))
     end
 end
 

--- a/test/graph.jl
+++ b/test/graph.jl
@@ -37,7 +37,7 @@ using DataStructures
 @testset "Graph tests" begin
     @testset "Bad extension" begin
         # file should have a .json or .shp extension
-        @test_throws ArgumentError BaseGraph("nonexistent.txt", "population", "assignment")
+        @test_throws DomainError BaseGraph("nonexistent.txt", "population", "assignment")
     end
 
     @testset "Reading node attributes from shapefile" begin


### PR DESCRIPTION
This PR closes #50.

# Description of changes
As per @pjrule's [comment](https://github.com/mggg/GerryChainJulia/pull/31#discussion_r462471026) on a previous PR, the way GerryChain currently attempts to read in a shapefile is by first trying to read it as a JSON, then trying to read it as a .shp file, and then rejecting if both fail. While this approach is clean, the way it is implemented now unfortunately can generate some confusing error messages for the user (see the "Before" picture that shows the full error output when the user attempts to read from a shapefile but the assignment column has the wrong type.)

In this PR, I change the `BaseGraph` function so that it explicitly checks the extension before attempting to read the shapefile. 

# Before
![image](https://user-images.githubusercontent.com/5581093/90178170-62a80980-dd60-11ea-855d-a117ff16ea71.png)
(Note how the core error - the type of the assignment column - is buried after two seemingly irrelevant messages.

# After
![image](https://user-images.githubusercontent.com/5581093/90178309-908d4e00-dd60-11ea-85e3-b67154014e5f.png)
Yay! The core error is immediately shown!