### PR TITLE
Allow user to pass in array for bins in plot_histograms

### DIFF
--- a/src/plot.jl
+++ b/src/plot.jl
@@ -128,10 +128,10 @@ end
 
 function score_histogram(score_values::Array{S, 1};
                          comparison_scores::Array=[],
-                         bins::Union{Nothing, Int}=nothing,
-                         range::Union{Nothing,Tuple}=nothing,
+                         bins::Union{Nothing, Int, Tuple}=nothing,
+                         range::Union{Nothing, Tuple}=nothing,
                          density::Bool=false,
-                         rwidth::Union{Nothing,T}=nothing) where {S<:Number, T<:Number}
+                         rwidth::Union{Nothing, T}=nothing) where {S<:Number, T<:Number}
     """ Creates a graph with histogram of the values of a score throughout
         the chain. Only applicable for scores of type PlanScore.
 

--- a/src/plot.jl
+++ b/src/plot.jl
@@ -128,7 +128,7 @@ end
 
 function score_histogram(score_values::Array{S, 1};
                          comparison_scores::Array=[],
-                         bins::Union{Nothing, Int, Tuple}=nothing,
+                         bins::Union{Nothing, Int, Vector}=nothing,
                          range::Union{Nothing, Tuple}=nothing,
                          density::Bool=false,
                          rwidth::Union{Nothing, T}=nothing) where {S<:Number, T<:Number}


### PR DESCRIPTION
Currently, we only allow the user to pass in an `Int` for the `bins` param of `score_histogram`. In this PR, we allow them to pass in a `Vector` as well, which is often used when users want flexibility over the exact boundaries of the histogram bars (e.g., having the bars centered on discrete values when plotting a histogram of counts).

# Example
```
score_histogram(chain_data, "efficiency_gap", rwidth=1, bins=collect(-0.025:0.025:0.150), comparison_scores=[("mean", 0.1), ("mean2", 0.06)])
```
![image](https://user-images.githubusercontent.com/5581093/90689688-4b1bc580-e225-11ea-9921-61d8bf7a006c.png)

**PROMISE**: I will update documentation to show this before merging!
