### PR TITLE
Save scores row-by-row to JSON file

### DIFF
--- a/src/GerryChain.jl
+++ b/src/GerryChain.jl
@@ -42,8 +42,8 @@ CompositeScore,
 AbstractScore,
 ChainScoreData,
 score_initial_partition, score_partition_from_proposal, eval_score_on_district,
-get_scores_at_step, eval_score_on_partition, save_scores, get_score_values,
-num_cut_edges,
+get_scores_at_step, eval_score_on_partition, save_scores_as_csv,
+save_scores_as_json, get_score_values, num_cut_edges,
 
 # acceptance functions
 always_accept, satisfies_acceptance_fn,

--- a/src/GerryChain.jl
+++ b/src/GerryChain.jl
@@ -42,8 +42,8 @@ CompositeScore,
 AbstractScore,
 ChainScoreData,
 score_initial_partition, score_partition_from_proposal, eval_score_on_district,
-get_scores_at_step, eval_score_on_partition, save_scores_as_csv,
-save_scores_as_json, get_score_values, num_cut_edges,
+get_scores_at_step, eval_score_on_partition, save_scores_to_csv,
+save_scores_to_json, get_score_values, num_cut_edges,
 
 # acceptance functions
 always_accept, satisfies_acceptance_fn,

--- a/src/scores.jl
+++ b/src/scores.jl
@@ -490,65 +490,85 @@ function flattened_score_names(chain_data::ChainScoreData)::Array{String, 1}
 end
 
 
-function save_scores(filename::String,
-                     chain_data::ChainScoreData,
-                     score_names::Array{String,1}=String[])
-    """ Save the `scores` in a CSV file named `filename`. We iterate through
-        each state in the history of the chain and write the CSV row-by-row.
+function save_scores_as_csv(filename::String,
+                            chain_data::ChainScoreData,
+                            score_names::Array{String,1}=String[])
+    """ Save the `scores` in a CSV file named `filename`.
     """
-    open(filename, "w") do f
-        if isempty(score_names) # by default, export all scores from chain
-            score_names = flattened_score_names(chain_data)
-        end
+     open(filename, "w") do f
+         if isempty(score_names) # by default, export all scores from chain
+             score_names = flattened_score_names(chain_data)
+         end
 
-        column_names = String[] # colum names of the CSV
-        nested_keys = Dict{String, String}() # map score key to nested key, if any
+         column_names = String[] # colum names of the CSV
+         nested_keys = Dict{String, String}() # map score key to nested key, if any
 
-        num_districts = nothing
-        for score_name in score_names
-            score, nested_key = get_score_by_name(chain_data, score_name)
-            if isnothing(score)
-                throw(KeyError("No score in the ChainScoreData object matches the name: $score_name"))
-            elseif score isa DistrictScore || score isa DistrictAggregate
-                if isnothing(num_districts)
-                    initial_vals = chain_data.step_values[1]
-                    if !isnothing(nested_key)
-                        initial_vals = initial_vals[nested_key]
-                    end
-                    num_districts = length(initial_vals[score_name])
-                end
-                # add new column for each district
-                district_columns = ["$(score_name)_$(i)" for i in 1:num_districts]
-                append!(column_names, district_columns)
-            elseif score isa CompositeScore
-                throw(ArgumentError("Cannot automatically save a CompositeScore to CSV. You may save a CompositeScore's child score."))
-            else # must be PlanScore
-                push!(column_names, score_name)
-            end
-            if !isnothing(nested_key)
-                nested_keys[score_name] = nested_key
-            end
-        end
-        # write column names
-        colname_row = hcat(column_names...) # turn into 1xn array
-        writedlm(f, colname_row, ',') # write intial row of column names
+         num_districts = nothing
+         for score_name in score_names
+             score, nested_key = get_score_by_name(chain_data, score_name)
+             if score isa DistrictScore || score isa DistrictAggregate
+                 if isnothing(num_districts)
+                     initial_vals = chain_data.step_values[1]
+                     if !isnothing(nested_key)
+                         initial_vals = initial_vals[nested_key]
+                     end
+                     num_districts = length(initial_vals[score_name])
+                 end
+                 # add new column for each district
+                 district_columns = ["$(score_name)_$(i)" for i in 1:num_districts]
+                 append!(column_names, district_columns)
+             elseif score isa CompositeScore
+                 throw(ArgumentError("Cannot automatically save a CompositeScore to CSV. You may save a CompositeScore's child score."))
+             elseif score isa PlanScore
+                 push!(column_names, score_name)
+             end
+             if !isnothing(nested_key)
+                 nested_keys[score_name] = nested_key
+             end
+         end
+         # write column names
+         colname_row = hcat(column_names...) # turn into 1xn array
+         writedlm(f, colname_row, ',') # write intial row of column names
 
-        # iterate through all steps of chain
-        query = ChainScoreQuery(score_names, chain_data)
-        for step_values in query
-            row_values = []
-            for key in score_names
-                if haskey(nested_keys, key)
-                    nested_key = nested_keys[key]
-                    append!(row_values, step_values[nested_key][key])
-                else
-                    append!(row_values, step_values[key])
-                end
-            end
-            # write one row for every state of the chain
-            writedlm(f, hcat(row_values...), ',')
-        end
-    end
+         # iterate through all steps of chain
+         query = ChainScoreQuery(score_names, chain_data)
+         for step_values in query
+             row_values = []
+             for key in score_names
+                 if haskey(nested_keys, key)
+                     nested_key = nested_keys[key]
+                     append!(row_values, step_values[nested_key][key])
+                 else
+                     append!(row_values, step_values[key])
+                 end
+             end
+             # write one row for every state of the chain
+             writedlm(f, hcat(row_values...), ',')
+         end
+     end
+ end
+
+
+ function save_scores_as_json(filename::String,
+                              chain_data::ChainScoreData,
+                              score_names::Array{String,1}=String[])
+     """ Save the `scores` in a JSON file named `filename`.
+     """
+     open(filename, "w") do f
+         if isempty(score_names) # by default, export all scores from chain
+             score_names = flattened_score_names(chain_data)
+         end
+
+         # iterate through all steps of chain
+         query = ChainScoreQuery(score_names, chain_data)
+         first_entry = true
+         println(f, "[")
+         for step_values in query
+             first_entry ? first_entry = false : print(f, ",\n")
+             print(f, JSON.json(step_values))
+         end
+         print(f, "\n]")
+     end
 end
 
 

--- a/src/scores.jl
+++ b/src/scores.jl
@@ -562,6 +562,9 @@ function save_scores_to_csv(filename::String,
          # iterate through all steps of chain
          query = ChainScoreQuery(score_names, chain_data)
          first_entry = true
+         # note that we manually write the brackets and commas because the point
+         # of writing the scores to the file row-by-row is that we never hold
+         # the entire array of scores in main memory. this may be brittle!
          println(f, "[")
          for step_values in query
              first_entry ? first_entry = false : print(f, ",\n")

--- a/src/scores.jl
+++ b/src/scores.jl
@@ -490,7 +490,7 @@ function flattened_score_names(chain_data::ChainScoreData)::Array{String, 1}
 end
 
 
-function save_scores_as_csv(filename::String,
+function save_scores_to_csv(filename::String,
                             chain_data::ChainScoreData,
                             score_names::Array{String,1}=String[])
     """ Save the `scores` in a CSV file named `filename`.
@@ -549,7 +549,7 @@ function save_scores_as_csv(filename::String,
  end
 
 
- function save_scores_as_json(filename::String,
+ function save_scores_to_json(filename::String,
                               chain_data::ChainScoreData,
                               score_names::Array{String,1}=String[])
      """ Save the `scores` in a JSON file named `filename`.

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,6 +3,7 @@ import LibGEOS
 import LibSpatialIndex
 using Test
 using LightGraphs
+using JSON
 
 const testdir = dirname(@__FILE__)
 square_grid_filepath = "./maps/test_grid_4x4.json"

--- a/test/scores.jl
+++ b/test/scores.jl
@@ -271,7 +271,7 @@
         votes_r = DistrictAggregate("electionR")
         scores = [
             DistrictAggregate("purple"),
-            PlanScore("cut_edges", cut_edges),
+            num_cut_edges("cut_edges"),
             CompositeScore("votes", [votes_d, votes_r])
         ]
         chain_data = ChainScoreData(scores, [])

--- a/test/scores.jl
+++ b/test/scores.jl
@@ -261,4 +261,42 @@
         @test d_vote_vals == [[6 6 6 6]; [8 4 6 6]]
         @test_throws ArgumentError get_score_values(chain_data, "nonexistent")
     end
+
+
+    @testset "save_scores_as_json()" begin
+        partition = Partition(graph, "assignment")
+        # initialize scores
+        all_scores = Array{Dict{String, Any}, 1}()
+        votes_d = DistrictAggregate("electionD")
+        votes_r = DistrictAggregate("electionR")
+        scores = [
+            DistrictAggregate("purple"),
+            PlanScore("cut_edges", cut_edges),
+            CompositeScore("votes", [votes_d, votes_r])
+        ]
+        chain_data = ChainScoreData(scores, [])
+        # get scores for initial plan
+        init_score_vals = score_initial_partition(graph, partition, scores)
+        push!(chain_data.step_values, init_score_vals)
+
+        # generate RecomProposal, update partition, and generate new set of scores
+        proposal = RecomProposal(1, 2, 51, 31, BitSet([1, 2, 3, 5, 6]), BitSet([4, 7, 8]))
+        update_partition!(partition, graph, proposal)
+        step_score_vals = score_partition_from_proposal(graph, partition, proposal, scores)
+        push!(chain_data.step_values, step_score_vals)
+
+        # get complete score dictionaries
+        complete_score_vals = [init_score_vals, score_initial_partition(graph, partition, scores)]
+        (fname, tio) = mktemp()
+        # check that return values look correct
+        save_scores_as_json(fname, chain_data)
+        step_vals = JSON.parsefile(fname)
+        for i in 1:length(step_vals)
+            @test step_vals[i]["purple"] == complete_score_vals[i]["purple"]
+            @test step_vals[i]["cut_edges"] == complete_score_vals[i]["cut_edges"]
+            @test step_vals[i]["votes"]["electionD"] == complete_score_vals[i]["votes"]["electionD"]
+            @test step_vals[i]["votes"]["electionR"] == complete_score_vals[i]["votes"]["electionR"]
+        end
+        close(tio)
+    end
 end

--- a/test/scores.jl
+++ b/test/scores.jl
@@ -263,7 +263,7 @@
     end
 
 
-    @testset "save_scores_as_json()" begin
+    @testset "save_scores_to_json()" begin
         partition = Partition(graph, "assignment")
         # initialize scores
         all_scores = Array{Dict{String, Any}, 1}()
@@ -289,7 +289,7 @@
         complete_score_vals = [init_score_vals, score_initial_partition(graph, partition, scores)]
         (fname, tio) = mktemp()
         # check that return values look correct
-        save_scores_as_json(fname, chain_data)
+        save_scores_to_json(fname, chain_data)
         step_vals = JSON.parsefile(fname)
         for i in 1:length(step_vals)
             @test step_vals[i]["purple"] == complete_score_vals[i]["purple"]


### PR DESCRIPTION
This PR closes issue #48. 

# Changes
This PR is smaller than it looks, I promise! The function `save_scores` has now been renamed `save_scores_to_csv` and there is a new function called `save_scores_to_json` (which is really tiny) that saves the scores in a chain to a JSON file. Each state of the chain is written as a row in the JSON file. 

# Usage
```
chain_data = recom_chain(graph, partition, pop_constraint, 10, scores)
save_scores_to_json("test.json", chain_data) # by default will save all scores in the chain
# alternatively, save_scores_to_json("test.json", chain_data, ["names", "of", "desired", "scores"])
```


**PROMISE:** I will update documentation to reflect these changes.