### PR TITLE
Add option to skip self loops for acceptance functions

### DIFF
--- a/src/flip.jl
+++ b/src/flip.jl
@@ -125,7 +125,9 @@ function flip_chain(graph::BaseGraph,
             no_self_loops:  If this is true, then a failure to accept a new state
                             is not considered a self-loop; rather, the chain
                             simply generates new proposals until the acceptance
-                            function is satisfied.
+                            function is satisfied. BEWARE - this can create
+                            infinite loops if the acceptance function is never
+                            satisfied!
     """
     steps_taken = 0
     first_scores = score_initial_partition(graph, partition, scores)
@@ -140,8 +142,7 @@ function flip_chain(graph::BaseGraph,
             # go back to the previous partition
             partition = partition.parent
             # if user specifies this behavior, we do not increment the steps
-            # taken if the acceptance function fails. BEWARE - this can create
-            # infinite loops if the acceptance function is never satisfied!
+            # taken if the acceptance function fails.
             if no_self_loops continue end
         end
         score_vals = score_partition_from_proposal(graph, partition, proposal, scores)

--- a/src/recom.jl
+++ b/src/recom.jl
@@ -215,7 +215,9 @@ function recom_chain(graph::BaseGraph,
             no_self_loops:  If this is true, then a failure to accept a new state
                             is not considered a self-loop; rather, the chain
                             simply generates new proposals until the acceptance
-                            function is satisfied.
+                            function is satisfied. BEWARE - this can create
+                            infinite loops if the acceptance function is never
+                            satisfied!
     """
     steps_taken = 0
     first_scores = score_initial_partition(graph, partition, scores)
@@ -229,8 +231,7 @@ function recom_chain(graph::BaseGraph,
             # go back to the previous partition
             partition = partition.parent
             # if user specifies this behavior, we do not increment the steps
-            # taken if the acceptance function fails. BEWARE - this can create
-            # infinite loops if the acceptance function is never satisfied!
+            # taken if the acceptance function fails.
             if no_self_loops continue end
         end
         score_vals = score_partition_from_proposal(graph, partition, proposal, scores)

--- a/src/recom.jl
+++ b/src/recom.jl
@@ -192,7 +192,8 @@ function recom_chain(graph::BaseGraph,
                      scores::Array{S, 1};
                      num_tries::Int=3,
                      acceptance_fn::F=always_accept,
-                     rng::AbstractRNG=Random.default_rng())::ChainScoreData where
+                     rng::AbstractRNG=Random.default_rng(),
+                     no_self_loops::Bool=false)::ChainScoreData where
                      {F<:Function, S<:AbstractScore}
     """ Runs a Markov Chain for `num_steps` steps using ReCom. Returns
         a ChainScoreData object which can be queried to retrieve the values of
@@ -211,6 +212,10 @@ function recom_chain(graph::BaseGraph,
                             proposal. Should accept a Partition as input.
             rng:            Random number generator. The user can pass in their
                             own; otherwise, we use the default RNG from Random.
+            no_self_loops:  If this is true, then a failure to accept a new state
+                            is not considered a self-loop; rather, the chain
+                            simply generates new proposals until the acceptance
+                            function is satisfied.
     """
     steps_taken = 0
     first_scores = score_initial_partition(graph, partition, scores)
@@ -223,6 +228,10 @@ function recom_chain(graph::BaseGraph,
         if custom_acceptance && !satisfies_acceptance_fn(partition, acceptance_fn)
             # go back to the previous partition
             partition = partition.parent
+            # if user specifies this behavior, we do not increment the steps
+            # taken if the acceptance function fails. BEWARE - this can create
+            # infinite loops if the acceptance function is never satisfied!
+            if no_self_loops continue end
         end
         score_vals = score_partition_from_proposal(graph, partition, proposal, scores)
         push!(chain_scores.step_values, score_vals)

--- a/test/flip.jl
+++ b/test/flip.jl
@@ -47,7 +47,7 @@
     @testset "no_self_loops" begin
         partition = Partition(graph, "assignment")
         # this is a dummy constraint
-        pop_constraint = PopulationConstraint(graph, "population", 10.0)
+        pop_constraint = PopulationConstraint(graph, partition, 10.0)
         cont_constraint = ContiguityConstraint()
         scores = [
             DistrictAggregate("electionD"),

--- a/test/flip.jl
+++ b/test/flip.jl
@@ -2,6 +2,11 @@
     graph = BaseGraph(square_grid_filepath, "population", "assignment")
     partition = Partition(graph, "assignment")
 
+    function accept_on_third_try()
+        counter = 0
+        return p -> (counter += 1) < 3 ? 0.0 : 1.0
+    end
+
     @testset "propose_random_flip()" begin
         flip_prop = GerryChain.propose_random_flip(graph, partition)
         pops = partition.dist_populations[[flip_prop.D₁, flip_prop.D₂]]
@@ -19,7 +24,7 @@
     @testset "flip_chain()" begin
         # this is a dummy constraint
         pop_constraint = PopulationConstraint(graph, "population", 10.0)
-        cont_constraint = cont_constraint = ContiguityConstraint()
+        cont_constraint = ContiguityConstraint()
         scores = [
             DistrictAggregate("electionD"),
             DistrictAggregate("electionR"),
@@ -37,5 +42,31 @@
         end
         # hacky way to run flip chain and test that it doesn't yield an exception
         @test !isa(run_chain(), Exception)
+    end
+
+    @testset "no_self_loops" begin
+        partition = Partition(graph, "assignment")
+        # this is a dummy constraint
+        pop_constraint = PopulationConstraint(graph, "population", 10.0)
+        cont_constraint = ContiguityConstraint()
+        scores = [
+            DistrictAggregate("electionD"),
+            DistrictAggregate("electionR"),
+            DistrictAggregate("purple"),
+            DistrictAggregate("pink"),
+        ]
+        num_steps = 1 # test 1 step (2 states) for now
+        f = accept_on_third_try()
+        chain_data = flip_chain(graph, partition, pop_constraint, cont_constraint, num_steps, scores, acceptance_fn=f)
+        @test get_scores_at_step(chain_data, 0) == get_scores_at_step(chain_data, 1)
+        # acceptance function should still return 0, because the acceptance function
+        # should only have been called once
+        @test f(nothing) == 0.0
+
+        f = accept_on_third_try() # reset f
+        chain_data = flip_chain(graph, partition, pop_constraint, cont_constraint, num_steps, scores, acceptance_fn=f, no_self_loops=true)
+        # acceptance function should now return 1, because the acceptance function
+        # should have been called until it started returning 1.0
+        @test f(nothing) == 1.0
     end
 end

--- a/test/recom.jl
+++ b/test/recom.jl
@@ -48,7 +48,7 @@
     @testset "no_self_loops" begin
         partition = Partition(graph, "assignment")
         # this is a dummy constraint
-        pop_constraint = PopulationConstraint(graph, "population", 10.0)
+        pop_constraint = PopulationConstraint(graph, partition, 10.0)
         scores = [
             DistrictAggregate("electionD"),
             DistrictAggregate("electionR"),

--- a/test/recom.jl
+++ b/test/recom.jl
@@ -1,6 +1,11 @@
 @testset "Recom tests" begin
     graph = BaseGraph(square_grid_filepath, "population", "assignment")
 
+    function accept_on_third_try()
+        counter = 0
+        return p -> (counter += 1) < 3 ? 0.0 : 1.0
+    end
+
     @testset "traverse_mst()" begin
         nodes = [1, 2, 3, 4, 5, 6, 7, 8]
         edges = [graph.adj_matrix[1,5], graph.adj_matrix[5,6], graph.adj_matrix[2,6],
@@ -38,5 +43,30 @@
         recom_chain(graph, partition, pop_constraint, num_steps, scores)
         # hacky way to run flip chain and test that it doesn't yield an exception
         @test !isa(run_chain(), Exception)
+    end
+
+    @testset "no_self_loops" begin
+        partition = Partition(graph, "assignment")
+        # this is a dummy constraint
+        pop_constraint = PopulationConstraint(graph, "population", 10.0)
+        scores = [
+            DistrictAggregate("electionD"),
+            DistrictAggregate("electionR"),
+            DistrictAggregate("purple"),
+            DistrictAggregate("pink"),
+        ]
+        num_steps = 1 # test 1 step (2 states) for now
+        f = accept_on_third_try()
+        chain_data = recom_chain(graph, partition, pop_constraint, num_steps, scores, acceptance_fn=f)
+        @test get_scores_at_step(chain_data, 0) == get_scores_at_step(chain_data, 1)
+        # acceptance function should still return 0, because the acceptance function
+        # should only have been called once
+        @test f(nothing) == 0.0
+
+        f = accept_on_third_try() # reset f
+        chain_data = recom_chain(graph, partition, pop_constraint, num_steps, scores, acceptance_fn=f, no_self_loops=true)
+        # acceptance function should now return 1, because the acceptance function
+        # should have been called until it started returning 1.0
+        @test f(nothing) == 1.0
     end
 end


### PR DESCRIPTION
# Description
As discussed with @pjrule , I am putting in a PR that allows the user to easily specify whether a failure to accept should constitute a self-loop (which counts towards the total # of steps) or whether self-loops should be disallowed (i.e., new proposals are generated until one satisfies an acceptance loop, at which point the step counter is incremented). Note that this feature has the potential to create infinite loops, if the user specifies `no_self_loops=true`. 

# Usage
```
chain_data = recom_chain(graph, partition, pop_constraint, num_steps, scores, acceptance_fn=f, no_self_loops=true)
```

**PROMISE**: I will update documentation before merging this code!