### PR TITLE
Add tagbot

### DIFF
--- a/.github/workflows/TagBot.yml
+++ b/.github/workflows/TagBot.yml
@@ -1,0 +1,12 @@
+name: TagBot
+on:
+  schedule:
+    - cron: 0 0 * * *
+  workflow_dispatch:
+jobs:
+  TagBot:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: JuliaRegistries/TagBot@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/Project.toml
+++ b/Project.toml
@@ -16,3 +16,13 @@ Shapefile = "8e980c4a-a4fe-5da2-b3a7-4b4b0353a2f4"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[compat]
+DataStructures = "0.17.9"
+JSON = "0.21.0"
+LibGEOS = "0.6.5"
+LibSpatialIndex = "0.2.0"
+LightGraphs = "1.3.0"
+PyPlot = "2.9.0"
+Shapefile = "0.6.2"
+julia = "1.3.1"


### PR DESCRIPTION
I added a config file for the TagBot, which should help us keep track of the release versions (https://github.com/marketplace/actions/julia-tagbot)

Also, I added a bunch of  compatibility upper bound versions because the Julia registry is not letting me register unless I do that, with this specific fail message: 
`The following dependencies do not have a compat entry that has an upper bound: DataStructures, JSON, LibGEOS, LibSpatialIndex, LightGraphs, PyPlot, Shapefile, julia. `
(https://github.com/JuliaRegistries/General/pull/20341)

My hope is that this PR will allow the package to be auto-merged, as well as set up the tag bot.