### PR TITLE
Consistently use ax object in plotting functions

### DIFF
--- a/src/plot.jl
+++ b/src/plot.jl
@@ -2,7 +2,7 @@ function score_boxplot(score_values::Array{S, 2};
                        sort_by_score::Bool=true,
                        label::String="GerryChain",
                        comparison_scores::Array=[],
-                       ax=nothing) where {S<:Number}
+                       ax::Union{Nothing, PyPlot.PyObject}=nothing) where {S<:Number}
     """ Produces a graph with multiple matplotlib box plots for the values of
         scores throughout the chain. Intended for use with district-level scores
         (DistrictAggregate, DistrictScore).
@@ -71,7 +71,7 @@ end
 function score_boxplot(score_values::Array{S, 1};
                        label::String="GerryChain",
                        comparison_scores::Array=[],
-                       ax=nothing) where {S<:Number}
+                       ax::Union{Nothing, PyPlot.PyObject}=nothing) where {S<:Number}
     """ Produces a single matplotlib box plot for the values of scores
         throughout the chain. Intended for use with plan-level scores.
 

--- a/src/plot.jl
+++ b/src/plot.jl
@@ -1,7 +1,8 @@
 function score_boxplot(score_values::Array{S, 2};
                        sort_by_score::Bool=true,
                        label::String="GerryChain",
-                       comparison_scores::Array=[]) where {S<:Number}
+                       comparison_scores::Array=[],
+                       ax=nothing) where {S<:Number}
     """ Produces a graph with multiple matplotlib box plots for the values of
         scores throughout the chain. Intended for use with district-level scores
         (DistrictAggregate, DistrictScore).
@@ -34,6 +35,9 @@ function score_boxplot(score_values::Array{S, 2};
                                   districts.
 
     """
+    if isnothing(ax)
+        _, ax = plt.subplots()
+    end
     if sort_by_score
         # within every step of the chain (i.e., within each row),
         # sort districts by value of the score
@@ -43,28 +47,30 @@ function score_boxplot(score_values::Array{S, 2};
     end
     # plot GerryChain boxplots
     medianprops=Dict("color" => "black") # make sure median line is black
-    plt.boxplot(score_values, showcaps=true, showbox=true, showfliers=false, medianprops=medianprops)
-    plt.xlabel("Indexed districts")
+    ax.boxplot(score_values, showcaps=true, showbox=true, showfliers=false, medianprops=medianprops)
+    ax.set_xlabel("Indexed districts")
     if length(comparison_scores) > 0
         # inserts a legend entry that shows the "GerryChain" label next to a
         # marker that looks like a boxplot
-        plt.plot([], [], color="k", marker="s", markerfacecolor="white", markersize=15, label=label)
+        ax.plot([], [], color="k", marker="s", markerfacecolor="white", markersize=15, label=label)
         # iterate through the comparison scores and plot them one by one
         for p in comparison_scores
             if !(p isa Tuple) || length(p) != 2 || !(p[1] isa String) || !(typeof(p[2]) <: AbstractArray)
                 throw(ArgumentError("Scores of comparison plans must be passed as tuples with structure (name of plan, [scores for each district])."))
             end
             plan_score_vals = sort_by_score ? sort(p[2]) : p[2]
-            plt.scatter(1:length(p[2]), plan_score_vals, label=p[1])
+            ax.scatter(1:length(p[2]), plan_score_vals, label=p[1])
         end
-        plt.legend()
+        ax.legend()
     end
+    return ax
 end
 
 
 function score_boxplot(score_values::Array{S, 1};
                        label::String="GerryChain",
-                       comparison_scores::Array=[]) where {S<:Number}
+                       comparison_scores::Array=[],
+                       ax=nothing) where {S<:Number}
     """ Produces a single matplotlib box plot for the values of scores
         throughout the chain. Intended for use with plan-level scores.
 
@@ -84,22 +90,25 @@ function score_boxplot(score_values::Array{S, 1};
                                   scoreᵢ is the value of the plan-wide score
                                   for the comparison plan.
     """
-    # plot GerryChain boxplot
+    if isnothing(ax)
+        _, ax = plt.subplots()
+    end
     medianprops=Dict("color" => "black") # make sure median line is black
-    plt.boxplot(score_values, showcaps=true, showbox=true, showfliers=false, medianprops=medianprops)
+    ax.boxplot(score_values, showcaps=true, showbox=true, showfliers=false, medianprops=medianprops)
     if length(comparison_scores) > 0
         # inserts a legend entry that shows the "GerryChain" label next to a
         # marker that looks like a boxplot
-        plt.plot([], [], color="k", marker="s", markerfacecolor="white", markersize=15, label=label)
+        ax.plot([], [], color="k", marker="s", markerfacecolor="white", markersize=15, label=label)
         # iterate through the comparison scores and plot them one by one
         for p in comparison_scores
             if !(p isa Tuple) || length(p) != 2 || !(p[1] isa String) || !(typeof(p[2]) <: Number)
                 throw(ArgumentError("Scores of comparison plans must be passed as tuples with structure (name of plan, score of plan)."))
             end
-            plt.scatter(1, p[2], label=p[1])
+            ax.scatter(1, p[2], label=p[1])
         end
-        plt.legend()
+        ax.legend()
     end
+    return ax
 end
 
 
@@ -121,8 +130,9 @@ function score_boxplot(chain_data::ChainScoreData, score_name::String; kwargs...
         throw(ArgumentError("Cannot make a boxplot of a CompositeScore"))
     end
     score_vals = get_score_values(chain_data.step_values, score, nested_key=nested_key)
-    score_boxplot(score_vals; kwargs...)
-    plt.ylabel(score_name)
+    ax = score_boxplot(score_vals; kwargs...)
+    ax.set_ylabel(score_name)
+    return ax
 end
 
 
@@ -131,7 +141,8 @@ function score_histogram(score_values::Array{S, 1};
                          bins::Union{Nothing, Int, Vector}=nothing,
                          range::Union{Nothing, Tuple}=nothing,
                          density::Bool=false,
-                         rwidth::Union{Nothing, T}=nothing) where {S<:Number, T<:Number}
+                         rwidth::Union{Nothing, T}=nothing,
+                         ax=nothing) where {S<:Number, T<:Number}
     """ Creates a graph with histogram of the values of a score throughout
         the chain. Only applicable for scores of type PlanScore.
 
@@ -149,7 +160,9 @@ function score_histogram(score_values::Array{S, 1};
                                   score for the comparison plan.
     """
     # plot GerryChain histogram
-    fig, ax = plt.subplots()
+    if isnothing(ax)
+        _, ax = plt.subplots()
+    end
     ax.hist(score_values, bins=bins, range=range, density=density, rwidth=rwidth)
     if length(comparison_scores) > 0
         # cycle through colors so vertical lines do not appear all blue
@@ -162,6 +175,7 @@ function score_histogram(score_values::Array{S, 1};
         end
         ax.legend()
     end
+    return ax
 end
 
 
@@ -183,7 +197,8 @@ function score_histogram(chain_data::ChainScoreData, score_name::String; kwargs.
         throw(ArgumentError("Can only create histogram plot of a PlanScore"))
     end
     score_vals = get_score_values(chain_data.step_values, score, nested_key=nested_key)
-    score_histogram(score_vals; kwargs...)
-    plt.ylabel("Frequency")
-    plt.xlabel(score_name)
+    ax = score_histogram(score_vals; kwargs...)
+    ax.set_ylabel("Frequency")
+    ax.set_xlabel(score_name)
+    return ax
 end

--- a/src/plot.jl
+++ b/src/plot.jl
@@ -33,6 +33,7 @@ function score_boxplot(score_values::Array{S, 2};
                                     (nameₓ, [w₁, w₂, ... , wᵤ])
                                   ], where there are x comparison plans and u
                                   districts.
+            ax                  : A PyPlot (matplotlib) Axis object
 
     """
     if isnothing(ax)
@@ -89,6 +90,7 @@ function score_boxplot(score_values::Array{S, 1};
                                   is a label that will appear on the legend and
                                   scoreᵢ is the value of the plan-wide score
                                   for the comparison plan.
+            ax                  : A PyPlot (matplotlib) Axis object
     """
     if isnothing(ax)
         _, ax = plt.subplots()
@@ -158,6 +160,7 @@ function score_histogram(score_values::Array{S, 1};
                                   where lᵢ is a label that will appear on the
                                   legend and scoreᵢ is the value of the plan-wide
                                   score for the comparison plan.
+            ax                  : A PyPlot (matplotlib) Axis object
     """
     # plot GerryChain histogram
     if isnothing(ax)

--- a/src/plot.jl
+++ b/src/plot.jl
@@ -144,7 +144,7 @@ function score_histogram(score_values::Array{S, 1};
                          range::Union{Nothing, Tuple}=nothing,
                          density::Bool=false,
                          rwidth::Union{Nothing, T}=nothing,
-                         ax=nothing) where {S<:Number, T<:Number}
+                         ax::Union{Nothing, PyPlot.PyObject}=nothing) where {S<:Number, T<:Number}
     """ Creates a graph with histogram of the values of a score throughout
         the chain. Only applicable for scores of type PlanScore.
 

--- a/test/plot.jl
+++ b/test/plot.jl
@@ -13,9 +13,9 @@
     chain_data = recom_chain(graph, partition, pop_constraint, num_steps, scores)
 
     @testset "score_boxplot()" begin
-        function boxplot_district_score()
+        function boxplot_district_score(ax=nothing)
             try
-                score_boxplot(chain_data, "electionD")
+                score_boxplot(chain_data, "electionD", ax=ax)
             catch ex
                 return ex
             end
@@ -30,13 +30,15 @@
         end
 
         @test !isa(boxplot_district_score(), Exception)
+        _, ax = GerryChain.PyPlot.plt.subplots()
+        @test !isa(boxplot_district_score(ax), Exception) # pass in existing ax object
         @test !isa(boxplot_plan_score(), Exception)
     end
 
     @testset "score_histogram()" begin
-        function histogram_no_comparison()
+        function histogram_no_comparison(ax=nothing)
             try
-                score_histogram(chain_data, "e_gap")
+                score_histogram(chain_data, "e_gap", ax=ax)
             catch ex
                 return ex
             end
@@ -51,6 +53,8 @@
         end
 
         @test !isa(histogram_no_comparison(), Exception)
+        _, ax = GerryChain.PyPlot.plt.subplots()
+        @test !isa(histogram_no_comparison(ax), Exception) # pass in existing ax object
         @test !isa(histogram_with_comparison(), Exception)
     end
 end


### PR DESCRIPTION
# Description
Following up on an earlier discussion, I convert all calls to `plt` to explicitly taking in an optional matplotlib `Axis` object (or creating one, if the user doesn't pass one in). This is a more common pattern that aligns with other plotting libraries that use matplotlib under the hood. I also explicitly return the `ax` object to the user.

# Usage 
Functionally, the usage for the user doesn't change much. Users can now do this:
```
_, ax = plt.subplots()
score_histogram(chain_data, "e_gap", ax=ax)
# maybe do some other stuff with the ax object!
```

# Example
```
plan1_bwratios = rand(18)
plan2_bwratios = rand(18)
ax = score_boxplot(chain_data, "dem_vote_share", comparison_scores=[("plan1", plan1_bwratios), ("plan2", plan2_bwratios)])
ax.legend(bbox_to_anchor=(0.5, 0.5))
ax.set_ylabel("Democratic vote share")
```
![image](https://user-images.githubusercontent.com/5581093/91453933-33e86380-e835-11ea-86bf-9b17754b3524.png)


**PROMISE**: I will update the documentation before this PR is merged!