### PR TITLE
point build icon to main branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # GerryChainJulia
 
-[![Build Status](https://travis-ci.com/mggg/GerryChainJulia.png)](https://travis-ci.com/mggg/GerryChainJulia)
+[![Build Status](https://api.travis-ci.com/mggg/GerryChainJulia.svg?branch=main)](https://travis-ci.com/mggg/GerryChainJulia)
 [![Code Coverage](https://codecov.io/gh/mggg/GerryChainJulia/branch/main/graph/badge.svg)](https://codecov.io/gh/mggg/GerryChainJulia/branch/main)
 An implementation of our beloved GerryChain in Julia
 


### PR DESCRIPTION
Addresses #72 .

Simply pointing the Travis build icon to the `main ` branch instead of whatever dev branch was pushed latest.