### PR TITLE
Remove assignment col arg from BaseGraph

### DIFF
--- a/src/constraints.jl
+++ b/src/constraints.jl
@@ -12,10 +12,10 @@ end
 
 
 function PopulationConstraint(graph::BaseGraph,
-                              partition::Partition,
+                              num_dists::Int,
                               population_col::AbstractString,
                               tolerance::Float64)
-    ideal_pop = graph.total_pop / partition.num_dists
+    ideal_pop = graph.total_pop / num_dists
 
     # no particular reason to not use floor() instead of ceil()
     min_pop = Int(ceil((1-tolerance) * ideal_pop))

--- a/src/constraints.jl
+++ b/src/constraints.jl
@@ -12,9 +12,10 @@ end
 
 
 function PopulationConstraint(graph::BaseGraph,
+                              partition::Partition,
                               population_col::AbstractString,
                               tolerance::Float64)
-    ideal_pop = graph.total_pop / graph.num_dists
+    ideal_pop = graph.total_pop / partition.num_dists
 
     # no particular reason to not use floor() instead of ceil()
     min_pop = Int(ceil((1-tolerance) * ideal_pop))

--- a/src/graph.jl
+++ b/src/graph.jl
@@ -3,7 +3,6 @@ abstract type AbstractGraph end
 struct BaseGraph<:AbstractGraph
     num_nodes::Int
     num_edges::Int
-    num_dists::Int
     total_pop::Int
     populations::Array{Int, 1}             # of length(num_nodes)
     adj_matrix::SparseMatrixCSC{Int, Int}
@@ -70,41 +69,6 @@ function population_to_int(raw_value::Number)::Int
     return raw_value isa Int ? raw_value : convert(Int, round(raw_value))
 end
 
-
-function get_assignments(node_attributes::Array,
-                         assignment_col::AbstractString)::Array{Int, 1}
-    """ Extracts the assignments for each node in a graph. First attempts
-        to parse the values of the assignments column as an Int; if it fails,
-        it assumes every unique string assignment corresponds to to a unique
-        district.
-    """
-    assignment_to_num = Dict{String, Int}() # map unique strings to integers
-    raw_assignments = get_attribute_by_key(node_attributes, assignment_col)
-    processed_assignments = zeros(length(raw_assignments))
-    for (i, raw_value) in enumerate(raw_assignments)
-        if raw_value isa Int
-            processed_assignments[i] = raw_value
-        elseif raw_value isa String
-            try
-                processed_assignments[i] = parse(Int, raw_assignment)
-            catch exception # if the String could not be read as an int
-                if !haskey(assignment_to_num, raw_value)
-                    assignment_to_num[raw_value] = length(assignment_to_num) + 1
-                end
-                processed_assignments[i] = assignment_to_num[raw_value]
-            end
-        else
-            message = """
-                District assignments should be Ints or Strings; type
-                $(typeof(raw_value)) was found instead.
-            """
-            throw(DomainError(raw_value, message))
-        end
-    end
-    return processed_assignments
-end
-
-
 function get_node_coordinates(row::Shapefile.Row)::Vector{Vector{Vector{Vector{Float64}}}}
     """ Construct an array of LibGEOS.Polygons from the given coordinates. The
         coordinates are structured in the following way. Each element in the
@@ -133,7 +97,6 @@ end
 
 function graph_from_shp(filepath::AbstractString,
                         pop_col::AbstractString,
-                        assignment_col::AbstractString,
                         adjacency::String="rook")::BaseGraph
     """ Constructs BaseGraph from .shp file.
     """
@@ -154,12 +117,10 @@ function graph_from_shp(filepath::AbstractString,
     neighbors = neighbors_from_graph(graph)
 
     populations =  get_attribute_by_key(attributes, pop_col, population_to_int)
-    assignments = get_assignments(attributes, assignment_col)
-    num_districts = length(Set(assignments))
     total_pop = sum(populations)
 
-    return BaseGraph(nv(graph), ne(graph), num_districts, total_pop,
-                     populations, adj_matrix, edge_src, edge_dst, neighbors,
+    return BaseGraph(nv(graph), ne(graph), total_pop, populations,
+                     adj_matrix, edge_src, edge_dst, neighbors,
                      graph, attributes)
 end
 
@@ -211,8 +172,7 @@ end
 
 
 function graph_from_json(filepath::AbstractString,
-                         pop_col::AbstractString,
-                         assignment_col::AbstractString)::BaseGraph
+                         pop_col::AbstractString)::BaseGraph
     """ Arguments:
 
         filepath:       file path to the .json file that contains the graph.
@@ -226,8 +186,6 @@ function graph_from_json(filepath::AbstractString,
                         destination node of the edge.
         pop_col:        the node attribute key whose accompanying value is the
                         population of that node
-        assignment_col: the node attribute key whose accompanying value is the
-                        assignment of that node (i.e., to a district)
 
     [1]: https://github.com/mggg/GerryChain/blob/c87da7e69967880abc99b781cd37468b8cb18815/gerrychain/graph/graph.py#L38
     """
@@ -235,10 +193,8 @@ function graph_from_json(filepath::AbstractString,
     nodes = raw_graph["nodes"]
     num_nodes = length(nodes)
 
-    # get populations, assignments and num_districts
+    # get populations
     populations =  get_attribute_by_key(nodes, pop_col, population_to_int)
-    assignments = get_assignments(nodes, assignment_col)
-    num_districts = length(Set(assignments))
     total_pop = sum(populations)
 
     # Generate the base SimpleGraph.
@@ -262,15 +218,14 @@ function graph_from_json(filepath::AbstractString,
     # get attributes
     attributes = get_attributes(nodes)
 
-    return BaseGraph(num_nodes, num_edges, num_districts, total_pop,
-                     populations, adj_matrix, edge_src, edge_dst, neighbors,
+    return BaseGraph(num_nodes, num_edges, total_pop, populations,
+                     adj_matrix, edge_src, edge_dst, neighbors,
                      simple_graph, attributes)
 end
 
 
 function BaseGraph(filepath::AbstractString,
-                   pop_col::AbstractString,
-                   assignment_col::AbstractString;
+                   pop_col::AbstractString;
                    adjacency::String="rook")::BaseGraph
     """ Builds the base Graph object. This is the underlying network of our
         districts, and its properties are immutable i.e they will not change
@@ -281,17 +236,15 @@ function BaseGraph(filepath::AbstractString,
                         information needed to construct the graph.
         pop_col:        the node attribute key whose accompanying value is the
                         population of that node
-        assignment_col: the node attribute key whose accompanying value is the
-                        assignment of that node (i.e., to a district)
         adjacency:      (Only used if the user specifies a filepath to a .shp
                         file.) Should be either "queen" or "rook"; "rook" by
                         default.
     """
     extension = uppercase(splitext(filepath)[2])
     if uppercase(extension) == ".JSON"
-        return graph_from_json(filepath, pop_col, assignment_col)
+        return graph_from_json(filepath, pop_col)
     elseif uppercase(extension) == ".SHP"
-        return graph_from_shp(filepath, pop_col, assignment_col, adjacency)
+        return graph_from_shp(filepath, pop_col, adjacency)
     else
         throw(DomainError(filepath, "Filepath must lead to valid JSON file or valid .shp/.dbf file."))
     end

--- a/src/graph.jl
+++ b/src/graph.jl
@@ -266,7 +266,7 @@ function induced_subgraph_edges(graph::BaseGraph, vlist::Array{Int, 1})::Array{I
     """ Returns a list of edges of the subgraph induced by vlist, which is an array of vertices.
     """
     allunique(vlist) || throw(ArgumentError("Vertices in subgraph list must be unique"))
-    induced_edges = Array{Int, 1}()
+    induced_edges = BitSet()
 
     vset = Set(vlist)
     for src in vlist
@@ -276,7 +276,7 @@ function induced_subgraph_edges(graph::BaseGraph, vlist::Array{Int, 1})::Array{I
             end
         end
     end
-    return induced_edges
+    return collect(induced_edges)
 end
 
 function get_subgraph_population(graph::BaseGraph, nodes::BitSet)::Int

--- a/src/partition.jl
+++ b/src/partition.jl
@@ -130,13 +130,12 @@ function get_district_adj_and_cut_edges(graph::BaseGraph,
 end
 
 function sample_adjacent_districts_randomly(partition::Partition,
-                                            num_dists::Int,
                                             rng::AbstractRNG)
     """ Randomly sample two adjacent districts and return them.
     """
     while true
-        D₁ = rand(rng, 1:num_dists)
-        D₂ = rand(rng, 1:num_dists)
+        D₁ = rand(rng, 1:partition.num_dists)
+        D₂ = rand(rng, 1:partition.num_dists)
         if partition.dist_adj[D₁, D₂] != 0
             return D₁, D₂
         end

--- a/src/recom.jl
+++ b/src/recom.jl
@@ -6,7 +6,7 @@ function sample_subgraph(graph::BaseGraph,
     """ Randomly sample two adjacent districts and returns them and their
         induced edges and nodes.
     """
-    D₁, D₂ = sample_adjacent_districts_randomly(partition, graph.num_dists, rng)
+    D₁, D₂ = sample_adjacent_districts_randomly(partition, partition.num_dists, rng)
 
     # take all their nodes
     nodes = union(partition.dist_nodes[D₁],

--- a/src/recom.jl
+++ b/src/recom.jl
@@ -6,7 +6,7 @@ function sample_subgraph(graph::BaseGraph,
     """ Randomly sample two adjacent districts and returns them and their
         induced edges and nodes.
     """
-    D₁, D₂ = sample_adjacent_districts_randomly(partition, partition.num_dists, rng)
+    D₁, D₂ = sample_adjacent_districts_randomly(partition, rng)
 
     # take all their nodes
     nodes = union(partition.dist_nodes[D₁],

--- a/src/scores.jl
+++ b/src/scores.jl
@@ -206,7 +206,7 @@ function eval_score_on_partition(graph::BaseGraph,
         Returns an array of the form [a₁, a₂, ..., aₘ], where m is the number
         of districts in the plan.
     """
-    all_districts = Array(1:graph.num_dists)
+    all_districts = Array(1:partition.num_dists)
     return eval_score_on_districts(graph, partition, score, all_districts)
 end
 

--- a/test/accept.jl
+++ b/test/accept.jl
@@ -1,5 +1,5 @@
 @testset "satisfies_acceptance_fn" begin
-    graph = BaseGraph(square_grid_filepath, "population", "assignment")
+    graph = BaseGraph(square_grid_filepath, "population")
     partition = Partition(graph, "assignment")
 
     inval_acc_fn_1(p) = "hi"

--- a/test/constraints.jl
+++ b/test/constraints.jl
@@ -1,6 +1,7 @@
 @testset "Population Constraint" begin
-    graph = BaseGraph(square_grid_filepath, "population", "assignment")
-    pop_constraint = PopulationConstraint(graph, "population", 0.1)
+    graph = BaseGraph(square_grid_filepath, "population")
+    partition = Partition(graph, "assignment")
+    pop_constraint = PopulationConstraint(graph, partition, "population", 0.1)
     balanced_proposal = RecomProposal(1, 3, 40, 42,
                                       BitSet([1, 2, 6]),
                                       BitSet([5, 9, 10, 13, 14]))
@@ -18,7 +19,7 @@
 end
 
 @testset "Contiguity Constraint" begin
-    graph = BaseGraph(cols_grid_filepath, "population", "assignment")
+    graph = BaseGraph(cols_grid_filepath, "population")
     partition = Partition(graph, "assignment")
     cont_constraint = ContiguityConstraint()
     discont_proposal = FlipProposal(5, 1, 0, 30, 42,

--- a/test/election.jl
+++ b/test/election.jl
@@ -6,16 +6,16 @@
             having this small helper function helps ensure that these tests
             are relatively isolated from other parts of the codebase.
         """
-        for d in 1:graph.num_dists
+        for d in 1:partition.num_dists
             # the first score should update all the vote counts
             election_tracker.scores[1].score_fn(graph, partition.dist_nodes[d], d)
         end
     end
 
     @testset "vote_updater()" begin
-        graph = BaseGraph(square_grid_filepath, "population", "assignment")
+        graph = BaseGraph(square_grid_filepath, "population")
         partition = Partition(graph, "assignment")
-        election = Election("Test Election", ["electionD", "electionR"], graph.num_dists)
+        election = Election("Test Election", ["electionD", "electionR"], partition.num_dists)
         election_tracker = ElectionTracker(election)
 
         update_vote_counts(graph, partition, election_tracker)
@@ -26,9 +26,9 @@
     end
 
     @testset "vote_count()" begin
-        graph = BaseGraph(square_grid_filepath, "population", "assignment")
+        graph = BaseGraph(square_grid_filepath, "population")
         partition = Partition(graph, "assignment")
-        election = Election("Test Election", ["electionD", "electionR"], graph.num_dists)
+        election = Election("Test Election", ["electionD", "electionR"], partition.num_dists)
 
         d_count = vote_count("votes_d", election, "electionD")
         r_count = vote_count("votes_r", election, "electionR")
@@ -45,9 +45,9 @@
     end
 
     @testset "vote_share()" begin
-        graph = BaseGraph(square_grid_filepath, "population", "assignment")
+        graph = BaseGraph(square_grid_filepath, "population")
         partition = Partition(graph, "assignment")
-        election = Election("Test Election", ["electionD", "electionR"], graph.num_dists)
+        election = Election("Test Election", ["electionD", "electionR"], partition.num_dists)
 
         d_share = vote_share("share_d", election, "electionD")
         r_share = vote_share("share_r", election, "electionR")
@@ -64,9 +64,9 @@
     end
 
     @testset "seats_won()" begin
-        graph = BaseGraph(square_grid_filepath, "population", "assignment")
+        graph = BaseGraph(square_grid_filepath, "population")
         partition = Partition(graph, "assignment")
-        election = Election("Test Election", ["electionD", "electionR"], graph.num_dists)
+        election = Election("Test Election", ["electionD", "electionR"], partition.num_dists)
         election_tracker = ElectionTracker(election)
         update_vote_counts(graph, partition, election_tracker)
         # Count seats won
@@ -100,9 +100,9 @@
     end
 
     @testset "mean_median()" begin
-        graph = BaseGraph(square_grid_filepath, "population", "assignment")
+        graph = BaseGraph(square_grid_filepath, "population")
         partition = Partition(graph, "assignment")
-        election = Election("Test Election", ["electionD", "electionR"], graph.num_dists)
+        election = Election("Test Election", ["electionD", "electionR"], partition.num_dists)
         election_tracker = ElectionTracker(election)
         update_vote_counts(graph, partition, election_tracker)
         # Measure mean median
@@ -138,14 +138,14 @@
         # in each district, D now win by 2 votes out of a total of 14 votes,
         # so wasted votes for R is (6*4) = 24, while wasted votes for D is
         # (1 * 4) = 4
-        graph = BaseGraph(square_grid_filepath, "population", "assignment")
+        graph = BaseGraph(square_grid_filepath, "population")
         graph.attributes[1]["electionD"] = 4
         graph.attributes[3]["electionD"] = 4
         graph.attributes[9]["electionD"] = 4
         graph.attributes[11]["electionD"] = 4
 
         partition = Partition(graph, "assignment")
-        election = Election("Test Election", ["electionD", "electionR"], graph.num_dists)
+        election = Election("Test Election", ["electionD", "electionR"], partition.num_dists)
         election_tracker = ElectionTracker(election)
         update_vote_counts(graph, partition, election_tracker)
 
@@ -159,15 +159,15 @@
         @test d_gap_score ≈ (4 - 24) / (14 * 4)
 
         # efficiency gap should break when there are more than two elections
-        bad_election = Election("Test Election", ["A", "B", "C"], graph.num_dists)
+        bad_election = Election("Test Election", ["A", "B", "C"], partition.num_dists)
         a_gap = efficiency_gap("test", bad_election, "A")
         @test_throws ArgumentError a_gap.score_fn(graph, partition)
     end
 
     @testset "ElectionTracker updates votes" begin
-        graph = BaseGraph(square_grid_filepath, "population", "assignment")
+        graph = BaseGraph(square_grid_filepath, "population")
         partition = Partition(graph, "assignment")
-        election = Election("Test Election", ["electionD", "electionR"], graph.num_dists)
+        election = Election("Test Election", ["electionD", "electionR"], partition.num_dists)
         election_tracker = ElectionTracker(election)
         update_vote_counts(graph, partition, election_tracker)
 

--- a/test/flip.jl
+++ b/test/flip.jl
@@ -1,5 +1,5 @@
 @testset "Flip tests" begin
-    graph = BaseGraph(square_grid_filepath, "population", "assignment")
+    graph = BaseGraph(square_grid_filepath, "population")
     partition = Partition(graph, "assignment")
 
     @testset "propose_random_flip()" begin
@@ -18,7 +18,7 @@
 
     @testset "flip_chain()" begin
         # this is a dummy constraint
-        pop_constraint = PopulationConstraint(graph, "population", 10.0)
+        pop_constraint = PopulationConstraint(graph, partition, "population", 10.0)
         cont_constraint = cont_constraint = ContiguityConstraint()
         scores = [
             DistrictAggregate("electionD"),

--- a/test/graph.jl
+++ b/test/graph.jl
@@ -37,7 +37,7 @@ using DataStructures
 @testset "Graph tests" begin
     @testset "Bad extension" begin
         # file should have a .json or .shp extension
-        @test_throws DomainError BaseGraph("nonexistent.txt", "population", "assignment")
+        @test_throws DomainError BaseGraph("nonexistent.txt", "population")
     end
 
     @testset "Reading node attributes from shapefile" begin
@@ -53,20 +53,11 @@ using DataStructures
         @test node_attributes == correct_attributes
     end
 
-    @testset "Check type of district assignments - get_assignments()" begin
-        graph = BaseGraph(square_shp_filepath, "population", "assignment")
-        # assignment that is a Float should throw an error
-        foreach(d -> d["assignment"] *= 1.0, graph.attributes) # convert Int to Float
-        @test_throws DomainError GerryChain.get_assignments(graph.attributes, "assignment")
-    end
-
     @testset "BaseGraph from shp() - rook adjacency" begin
-        graph = BaseGraph(square_shp_filepath, "population", "assignment")
+        graph = BaseGraph(square_shp_filepath, "population")
         @test graph.num_nodes == 4
         @test graph.num_edges == 4
         @test graph.total_pop == 20
-        @test graph.num_dists == 4
-
         @test graph.populations == [2, 4, 6, 8]
         @test graph.adj_matrix[1, 2] != 0
         @test graph.adj_matrix[1, 3] != 0
@@ -75,11 +66,10 @@ using DataStructures
     end
 
     @testset "BaseGraph from shp() - queen adjacency" begin
-        graph = BaseGraph(square_shp_filepath, "population", "assignment", adjacency="queen")
+        graph = BaseGraph(square_shp_filepath, "population", adjacency="queen")
         @test graph.num_nodes == 4
         @test graph.num_edges == 6 # queen adjacency means all 6 edges
         @test graph.total_pop == 20
-        @test graph.num_dists == 4
 
         @test graph.populations == [2, 4, 6, 8]
         # with queen adjacency, all squares should be adjacent to each other
@@ -91,12 +81,11 @@ using DataStructures
         @test graph.adj_matrix[3, 4] != 0
     end
 
-    graph = BaseGraph(square_grid_filepath, "population", "assignment")
+    graph = BaseGraph(square_grid_filepath, "population")
 
     @test graph.num_nodes == 16
     @test graph.num_edges == 24
     @test graph.total_pop == 164
-    @test graph.num_dists == 4
 
     @testset "Populations" begin
         for i in [1, 7, 9, 16]
@@ -123,6 +112,13 @@ using DataStructures
         end
     end
 
+    @testset "Check type of district assignments - get_assignments()" begin
+        partition = Partition(graph, "assignment")
+        # assignment that is a Float should throw an error
+        foreach(d -> d["assignment"] *= 1.0, graph.attributes) # convert Int to Float
+        @test_throws DomainError GerryChain.get_assignments(graph.attributes, "assignment")
+    end
+    
     # test the edge arrays
     @test graph.edge_src[graph.adj_matrix[10,11]] in (10,11)
     @test graph.edge_dst[graph.adj_matrix[11,10]] in (10,11)

--- a/test/partition.jl
+++ b/test/partition.jl
@@ -32,8 +32,9 @@
 
 # partition tests
 @testset "Partition tests" begin
-    graph = BaseGraph(square_grid_filepath, "population", "assignment")
+    graph = BaseGraph(square_grid_filepath, "population")
     partition = Partition(graph, "assignment")
+    @test partition.num_dists == 4
 
     @test partition.num_cut_edges == 8
     @test partition.dist_populations[1] == 41
@@ -42,8 +43,8 @@
     @test partition.dist_populations[4] == 41
 
     @testset "District Adjacency" begin
-        for i in 1:graph.num_dists
-            for j in 1:graph.num_dists
+        for i in 1:partition.num_dists
+            for j in 1:partition.num_dists
                 @test partition.dist_adj[i,j] == partition.dist_adj[j,i]
             end
         end

--- a/test/plot.jl
+++ b/test/plot.jl
@@ -1,9 +1,9 @@
 @testset "Plotting tests" begin
-    graph = BaseGraph(square_grid_filepath, "population", "assignment")
+    graph = BaseGraph(square_grid_filepath, "population")
     partition = Partition(graph, "assignment")
     # this is a dummy constraint
-    pop_constraint = PopulationConstraint(graph, "population", 10.0)
-    election = Election("election", ["electionD", "electionR"], graph.num_dists)
+    pop_constraint = PopulationConstraint(graph, partition, "population", 10.0)
+    election = Election("election", ["electionD", "electionR"], partition.num_dists)
     scores = [
         DistrictAggregate("electionD"),
         DistrictAggregate("electionR"),

--- a/test/recom.jl
+++ b/test/recom.jl
@@ -1,5 +1,5 @@
 @testset "Recom tests" begin
-    graph = BaseGraph(square_grid_filepath, "population", "assignment")
+    graph = BaseGraph(square_grid_filepath, "population")
 
     @testset "traverse_mst()" begin
         nodes = [1, 2, 3, 4, 5, 6, 7, 8]
@@ -19,7 +19,7 @@
     @testset "recom_chain()" begin
         partition = Partition(graph, "assignment")
         # this is a dummy constraint
-        pop_constraint = PopulationConstraint(graph, "population", 10.0)
+        pop_constraint = PopulationConstraint(graph, partition, "population", 10.0)
         scores = [
             DistrictAggregate("electionD"),
             DistrictAggregate("electionR"),

--- a/test/scores.jl
+++ b/test/scores.jl
@@ -2,7 +2,7 @@
 # We generate a new Partition for each testset because the partition object is
 # modified in each testset
 @testset "Score tests" begin
-    graph = BaseGraph(square_grid_filepath, "population", "assignment")
+    graph = BaseGraph(square_grid_filepath, "population")
 
     function calc_disparity(graph, nodes, district)
         diff = 0


### PR DESCRIPTION
This PR removes the requirement for BaseGraph to take an `assignment` argument. This issue has been brought up in the past -- "Why is BaseGraph and Partition both taking the assignment column, isn't it enough to pass it into just one?". In removing the `assignment` argument requirement from BaseGraph it makes the code more elegant. 

Previous usage:
```
graph = BaseGraph(filepath, POP_COL, ASSIGNMENT_COL)
partition = Partition(graph, ASSIGNMENT_COL)
```
New usage:
```
graph = BaseGraph(filepath, POP_COL)
partition = Partition(graph, ASSIGNMENT_COL)
```

This change was actually forced, in my opinion, by me trying to add the functionality of adding seed partition generating methods. In a non-trivial number of occasions at the lab we work with shapefiles without assignments and we generate a seed partition. If it is a requirement for the `BaseGraph` to take in an assignment column when we don't have one, we cannot even instantiate the `BaseGraph`! 

What this means:
* The `num_dists` property in `BaseGraph` gets transferred over to `Partition`, and this leads to a bunch of changes in the codebase.
* This paves way to new PRs on the pipeline: 1. removing the `population_col` argument in `PopulationConstraint` and 2. A PR to generate seed partitions!

That is the only major change this PR makes -- it touches a lot of files because the instantiation of `BaseGraph` is everywhere, especially in the tests.

Reminder to self / Promise: Need to update the documentation after the PR is merged!