### PR TITLE
Remove unused population_col argument from PopulationConstraint

### DIFF
--- a/src/constraints.jl
+++ b/src/constraints.jl
@@ -12,7 +12,6 @@ end
 
 
 function PopulationConstraint(graph::BaseGraph,
-                              population_col::AbstractString,
                               tolerance::Float64)
     ideal_pop = graph.total_pop / graph.num_dists
 

--- a/test/constraints.jl
+++ b/test/constraints.jl
@@ -1,6 +1,6 @@
 @testset "Population Constraint" begin
     graph = BaseGraph(square_grid_filepath, "population", "assignment")
-    pop_constraint = PopulationConstraint(graph, "population", 0.1)
+    pop_constraint = PopulationConstraint(graph, 0.1)
     balanced_proposal = RecomProposal(1, 3, 40, 42,
                                       BitSet([1, 2, 6]),
                                       BitSet([5, 9, 10, 13, 14]))

--- a/test/flip.jl
+++ b/test/flip.jl
@@ -18,7 +18,7 @@
 
     @testset "flip_chain()" begin
         # this is a dummy constraint
-        pop_constraint = PopulationConstraint(graph, "population", 10.0)
+        pop_constraint = PopulationConstraint(graph,  10.0)
         cont_constraint = cont_constraint = ContiguityConstraint()
         scores = [
             DistrictAggregate("electionD"),

--- a/test/plot.jl
+++ b/test/plot.jl
@@ -2,7 +2,7 @@
     graph = BaseGraph(square_grid_filepath, "population", "assignment")
     partition = Partition(graph, "assignment")
     # this is a dummy constraint
-    pop_constraint = PopulationConstraint(graph, "population", 10.0)
+    pop_constraint = PopulationConstraint(graph, 10.0)
     election = Election("election", ["electionD", "electionR"], graph.num_dists)
     scores = [
         DistrictAggregate("electionD"),

--- a/test/recom.jl
+++ b/test/recom.jl
@@ -19,7 +19,7 @@
     @testset "recom_chain()" begin
         partition = Partition(graph, "assignment")
         # this is a dummy constraint
-        pop_constraint = PopulationConstraint(graph, "population", 10.0)
+        pop_constraint = PopulationConstraint(graph, 10.0)
         scores = [
             DistrictAggregate("electionD"),
             DistrictAggregate("electionR"),


### PR DESCRIPTION
There is an unused `population_col` argument in `PopulationConstraint` that was living in our codebase rent-free and it simply was time for it to go.