### PR TITLE
fix duplicate induced edges bug

### DIFF
--- a/src/graph.jl
+++ b/src/graph.jl
@@ -313,7 +313,7 @@ function induced_subgraph_edges(graph::BaseGraph, vlist::Array{Int, 1})::Array{I
     """ Returns a list of edges of the subgraph induced by vlist, which is an array of vertices.
     """
     allunique(vlist) || throw(ArgumentError("Vertices in subgraph list must be unique"))
-    induced_edges = Array{Int, 1}()
+    induced_edges = Set{Int}()
 
     vset = Set(vlist)
     for src in vlist
@@ -323,7 +323,7 @@ function induced_subgraph_edges(graph::BaseGraph, vlist::Array{Int, 1})::Array{I
             end
         end
     end
-    return induced_edges
+    return collect(induced_edges)
 end
 
 function get_subgraph_population(graph::BaseGraph, nodes::BitSet)::Int

--- a/test/graph.jl
+++ b/test/graph.jl
@@ -141,13 +141,15 @@ using DataStructures
     @test LightGraphs.ne(graph.simple_graph) == graph.num_edges
 
     # test induced_subgraph
-    @test begin
+    @testset "induced_subgraph_edges()" begin
         induced_edges = induced_subgraph_edges(graph, [1, 2, 3, 4])
+        @test sort(induced_edges) == sort([1, 3, 5])
+
         induced_vertices = Set{Int}()
         for edge in induced_edges
             push!(induced_vertices, graph.edge_src[edge], graph.edge_dst[edge])
         end
-        induced_vertices == Set{Int}([1, 2, 3, 4])
+        @test induced_vertices == Set{Int}([1, 2, 3, 4])
     end
     @test_throws ArgumentError induced_subgraph_edges(graph, [1, 1, 4])
 


### PR DESCRIPTION
Turns out `induced_subgraph_edges()` was returning _duplicated_ edges ie if the expected return value was [3, 4, 5] it would return [3, 3, 4, 4, 5, 5]. 

This is because of the way we loop over the adjacency list (see lines 318-325 in `src/graph.jl`. 

This PR fixes this issue, and adds a test for it. 

Additionally, this bug might be why we might occasionally be having chain hanging issues, but I haven't thought hard about that yet.