### PR TITLE
make error msg on eval_on() funcs better

### DIFF
--- a/src/scores.jl
+++ b/src/scores.jl
@@ -151,7 +151,7 @@ function eval_score_on_district(graph::BaseGraph,
     try
         return score.score_fn(graph, partition.dist_nodes[district], district)
     catch e # Check if the user-specified method was constructed incorrectly
-        if isa(e, MethodError)
+        if !applicable(score.score_fn, graph, partition)
             error_msg = "DistrictScore function must accept graph, array of nodes, and district index."
             throw(ArgumentError(error_msg))
         end
@@ -219,7 +219,7 @@ function eval_score_on_partition(graph::BaseGraph,
     try
         return score.score_fn(graph, partition)
     catch e # Check if the user-specified method was constructed incorrectly
-        if isa(e, MethodError)
+        if !applicable(score.score_fn, graph, partition)
             error_msg = "PlanScore function must accept graph and partition."
             throw(ArgumentError(error_msg))
         end

--- a/test/scores.jl
+++ b/test/scores.jl
@@ -87,9 +87,15 @@
         @test eval_score_on_district(graph, partition, score_race, 1) == 28
         @test eval_score_on_district(graph, partition, score_election_d, 2) == 6
 
-        broken_fn = x -> 2*x # district score functions must accept graph, node array, and district index
-        bad_score = DistrictScore("break", broken_fn)
-        @test_throws ArgumentError eval_score_on_district(graph, partition, bad_score, 1)
+        broken_fn_wrong_args = x -> 2*x # district score functions must accept graph, node array, and district index
+        wrong_args_score = DistrictScore("break", broken_fn_wrong_args)
+        @test_throws ArgumentError eval_score_on_district(graph, partition, wrong_args_score, 1)
+
+        function broken_fn_inner_bug(graph, district_nodes, district_index)
+            "1" + 1 # this is an invalid operation
+        end
+        inner_bug_score = PlanScore("broken2", broken_fn_inner_bug)
+        @test_throws MethodError eval_score_on_district(graph, partition, inner_bug_score, 1)
 
         race_gap = DistrictScore("race_gap", calc_disparity)
         @test eval_score_on_district(graph, partition, race_gap, 3) == -15
@@ -109,11 +115,17 @@
         @test eval_score_on_partition(graph, partition, race_gap) == gaps
 
         # PlanScore should take a graph & partition
-        function bad_plan_fn(x)
+        function bad_plan_fn_wrong_args(x)
             return x
         end
-        broken_score = PlanScore("broken", bad_plan_fn)
-        @test_throws ArgumentError eval_score_on_partition(graph, partition, broken_score)
+        wrong_args_score = PlanScore("broken", bad_plan_fn_wrong_args)
+        @test_throws ArgumentError eval_score_on_partition(graph, partition, wrong_args_score)
+
+        function bad_plan_fn_inner_bug(graph::BaseGraph, partition::Partition)
+            "1" + 1 # this is an invalid operation
+        end
+        inner_bug_score = PlanScore("broken2", bad_plan_fn_inner_bug)
+        @test_throws MethodError eval_score_on_partition(graph, partition, inner_bug_score)
 
         cut_edges_score = num_cut_edges("cut_edges")
         @test eval_score_on_partition(graph, partition, cut_edges_score) == 8


### PR DESCRIPTION
This PR is to address #68. When the `score_fn` errors out from within, the error message was still `PlanScore function must accept graph and partition.` and this was very confusing because graph and partition were actually passed in. The following picture illustrates this issue:
![bug](https://user-images.githubusercontent.com/18491804/94982209-cb149b00-0506-11eb-9a7a-cf808d9699a9.png)

The behavior we actually want is this: If the function does not take a `BaseGraph` and `Partition` as args then we want to emit that error message, but if the user has messed up the function themself then we want Julia's own engine to error out and point to the specific line. 

With the help of the nifty [applicable()](http://www.jlhub.com/julia/manual/en/function/applicable) function, this can be achieved with minimal change.

After the fix we see the following behavior when there is an error within the user's defined `PlanScore`:
![correct_behavior](https://user-images.githubusercontent.com/18491804/94982310-6efe4680-0507-11eb-96f7-1f730c041490.png)
and the following behavior when the user has messed up the `PlanScore`'s function signature:
![desired](https://user-images.githubusercontent.com/18491804/94982326-92c18c80-0507-11eb-9b55-4f90135ea66f.png)

Made the corresponding changes to `DistrictScore` too, and added tests.
