### PR TITLE
remove nightly builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: julia
 julia:
-  - nightly
+  # - nightly
   - 1.3.1
 os:
   - osx
@@ -11,8 +11,8 @@ before_script:
   - export PYTHON="" # ensure that PyPlot installs matplotlib using Conda.jl
 
 matrix:
-  allow_failures:
-    - julia: nightly
+  # allow_failures:
+  #   - julia: nightly
   include:
     - stage: "Documentation"
       julia: 1.3.1


### PR DESCRIPTION
We let the nightly builds fail anyway, and it annoys me how long it takes to run the tests. 

Also, Travis is taking away credits for this runtime now, so for the timebeing...