### PR TITLE
fix bug that gives correct error for wrong DistrictScore argument

### DIFF
--- a/src/scores.jl
+++ b/src/scores.jl
@@ -210,7 +210,7 @@ function eval_score_on_district(
     try
         return score.score_fn(graph, partition.dist_nodes[district], district)
     catch e # Check if the user-specified method was constructed incorrectly
-        if !applicable(score.score_fn, graph, partition)
+        if !applicable(score.score_fn, graph, partition.dist_nodes[district], district)
             error_msg = "DistrictScore function must accept graph, array of nodes, and district index."
             throw(ArgumentError(error_msg))
         end

--- a/test/scores.jl
+++ b/test/scores.jl
@@ -99,7 +99,7 @@
         function broken_fn_inner_bug(graph, district_nodes, district_index)
             "1" + 1 # this is an invalid operation
         end
-        inner_bug_score = PlanScore("broken2", broken_fn_inner_bug)
+        inner_bug_score = DistrictScore("broken2", broken_fn_inner_bug)
         @test_throws MethodError eval_score_on_district(
             graph,
             partition,


### PR DESCRIPTION
Bug fix.

Bug:
Previously, if there was a MethodError inside a DistrictScore, the program would give the message "DistrictScore function must accept graph, array of nodes, and district index." which was not true, we would want the Julia engine to error out instead. This bug was introduced by me in #81 when I put in a line copied from the PlanScore function. Sadly, the tests did not catch it because the test was also "templated" from the PlanScore case. 

Fix: 
Now the error is actually from the Julia engine, as expected!

