### PR TITLE
change vote counts to be floats

### DIFF
--- a/src/election.jl
+++ b/src/election.jl
@@ -1,7 +1,7 @@
 mutable struct Election
     name::String
     parties::Array{String,1}
-    vote_counts::Array{Int64,2} # row: district, col: votes by party
+    vote_counts::Array{Float64,2} # row: district, col: votes by party
     vote_shares::Array{Float64,2} # row: district, col: vote share by party
 end
 
@@ -155,15 +155,15 @@ function mean_median(name::String, election::Election, party::String)::PlanScore
 end
 
 """
-    wasted_votes(party₁_votes::Int,
-                 party₂_votes::Int)
+    wasted_votes(party₁_votes::Float64,
+                 party₂_votes::Float64)
 
 Computes the number of votes "wasted" by each party. Wasted votes are
 votes that are either more than necessary than the party needed to win
 a seat or votes in a race that party lost. In a tie, all votes are
 considered to have been wasted.
 """
-function wasted_votes(party₁_votes::Int, party₂_votes::Int)
+function wasted_votes(party₁_votes::Float64, party₂_votes::Float64)
     total = party₁_votes + party₂_votes
 
     if party₁_votes > party₂_votes
@@ -226,7 +226,7 @@ end
 """
     ElectionTracker(election::Election,
                     scores::Array{S, 1}=AbstractScore[])::CompositeScore where {S <: AbstractScore}
-                    
+
 The ElectionTracker method returns a CompositeScore that first updates
 the vote count / share for changed districts and then proceeds to
 run other scores (such as vote count for a particular party, partisan

--- a/test/election.jl
+++ b/test/election.jl
@@ -135,8 +135,8 @@
 
     @testset "wasted_votes()" begin
         party₁_waste, party₂_waste = wasted_votes(52.0, 50.0)
-        @test party₁_waste == 1.
-        @test party₂_waste == 50.
+        @test party₁_waste == 1.0
+        @test party₂_waste == 50.0
     end
 
     @testset "efficiency_gap()" begin

--- a/test/election.jl
+++ b/test/election.jl
@@ -22,7 +22,7 @@
         update_vote_counts(graph, partition, election_tracker)
 
         # just test vote counts / shares on district 1
-        @test election.vote_counts[1, 1] == 6 # votes for electionD
+        @test election.vote_counts[1, 1] == 6.0 # votes for electionD
         @test election.vote_shares[1, 2] == 0.5 # votes for electionR
     end
 
@@ -134,9 +134,9 @@
     end
 
     @testset "wasted_votes()" begin
-        party₁_waste, party₂_waste = wasted_votes(52, 50)
-        @test party₁_waste == 1
-        @test party₂_waste == 50
+        party₁_waste, party₂_waste = wasted_votes(52.0, 50.0)
+        @test party₁_waste == 1.
+        @test party₂_waste == 50.
     end
 
     @testset "efficiency_gap()" begin


### PR DESCRIPTION
Ari from Princeton was running into this issue where the `vote_counts` in his shapefile were floats, but GerryChain expected it to be `Int` in the definition of the `Election` struct.

I think vote counts should be allowed to be Floats, especially since they might need to be pro-rated to lower geographical units. 

This PR makes that change, and also changes the `wasted_votes()` function and corresponding tests that expected `vote_counts` to be `Int`s.