### PR TITLE
Ensure that random_kruskal_mst doesn't generate the same spanning tree every time

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,8 +7,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        julia-version: ['1.5.3']
-        os: [ubuntu-latest, windows-latest, macos-10.15]
+        julia-version: ['1.6.1']
+        os: [ubuntu-latest, windows-latest]
     
     steps:
     - uses: actions/checkout@v2

--- a/src/balance_edges.jl
+++ b/src/balance_edges.jl
@@ -52,7 +52,7 @@ end
     random_kruskal_mst(graph::BaseGraph,
                        edges::Array{Int, 1},
                        nodes::Array{Int, 1},
-                       rng=Random.default_rng())::BitSet
+                       rng::AbstractRNG=Random.default_rng())
 
 Generates and returns a random minimum spanning tree from the subgraph induced
 by `edges` and `nodes`, using Kruskal's MST algorithm.
@@ -65,6 +65,7 @@ The `graph` represents the entire graph of the plan, where as `edges` and
 - graph: Underlying Graph object
 - edges: Array of edges of the sub-graph
 - nodes: Set of nodes of the sub-graph
+- rng: A random number generator that implements the [AbstractRNG type](https://docs.julialang.org/en/v1/stdlib/Random/#Random.AbstractRNG) (e.g. `Random.default_rng()` or `MersenneTwister(1234)`)
 
 *Returns* a BitSet of edges that form a mst.
 """
@@ -72,7 +73,7 @@ function random_kruskal_mst(
     graph::BaseGraph,
     edges::Array{Int,1},
     nodes::Array{Int,1},
-    rng = Random.default_rng(),
+    rng::AbstractRNG = Random.default_rng(),
 )::BitSet
     weights = rand(rng, length(edges))
     return kruskal_mst(graph, edges, nodes, weights)

--- a/src/balance_edges.jl
+++ b/src/balance_edges.jl
@@ -52,7 +52,7 @@ end
     random_kruskal_mst(graph::BaseGraph,
                        edges::Array{Int, 1},
                        nodes::Array{Int, 1},
-                       rng=MersenneTwister(1234))::BitSet
+                       rng=Random.default_rng())::BitSet
 
 Generates and returns a random minimum spanning tree from the subgraph induced
 by `edges` and `nodes`, using Kruskal's MST algorithm.
@@ -72,7 +72,7 @@ function random_kruskal_mst(
     graph::BaseGraph,
     edges::Array{Int,1},
     nodes::Array{Int,1},
-    rng = MersenneTwister(1234),
+    rng = Random.default_rng(),
 )::BitSet
     weights = rand(rng, length(edges))
     return kruskal_mst(graph, edges, nodes, weights)

--- a/src/recom.jl
+++ b/src/recom.jl
@@ -189,7 +189,7 @@ function get_valid_proposal(
         D₁, D₂, sg_edges, sg_nodes = sample_subgraph(graph, partition, rng)
 
         for _ = 1:num_tries
-            mst_edges = random_kruskal_mst(graph, sg_edges, collect(sg_nodes))
+            mst_edges = random_kruskal_mst(graph, sg_edges, collect(sg_nodes), rng)
 
             # see if we can get a population-balanced cut in this mst
             proposal = get_balanced_proposal(

--- a/src/recom.jl
+++ b/src/recom.jl
@@ -177,6 +177,9 @@ end
     - pop_constraint: PopulationConstraint to adhere to
     - num_tries:      num times to try getting a balanced cut from a subgraph
                       before giving up
+    - rng:            A random number generator that implements the 
+                      [AbstractRNG type](https://docs.julialang.org/en/v1/stdlib/Random/#Random.AbstractRNG) 
+                      (e.g. `Random.default_rng()` or `MersenneTwister(1234)`)
 """
 function get_valid_proposal(
     graph::BaseGraph,

--- a/src/recom.jl
+++ b/src/recom.jl
@@ -275,7 +275,9 @@ step of the chain.
                     representing the likelihood of accepting the
                     proposal. Should accept a `Partition` as input.
 - rng:              Random number generator. The user can pass in their
-                    own; otherwise, we use the default RNG from Random.
+                    own; otherwise, we use the default RNG from Random. Must
+                    implement the [AbstractRNG type](https://docs.julialang.org/en/v1/stdlib/Random/#Random.AbstractRNG) 
+                    (e.g. `Random.default_rng()` or `MersenneTwister(1234)`).
 - no\\_self\\_loops: If this is true, then a failure to accept a new state
                     is not considered a self-loop; rather, the chain
                     simply generates new proposals until the acceptance


### PR DESCRIPTION
One of the reasons why we only get constant scores in some chains is because of a different bug, which is caused by `random_kruskal_mst` being re-seeded with the same static seed (`1234`) every time it is called. In some cases, when combined with other strange behavior that needs to be chased down, this results in a totally deterministic step function -- the chain never takes more than one step because every proposal is the same. This issue has been partially addressed in this PR.